### PR TITLE
feat(docs): publish pages only after release, add dark mode and version banner

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,8 @@
 name: docs
 
 on:
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -19,9 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
       - name: Configure Pages
         id: pages
         uses: actions/configure-pages@v5
+      - name: Inject release version
+        working-directory: docs
+        run: |
+          mkdir -p _data
+          echo "release: $DOCS_VERSION" > _data/version.yml
+        env:
+          DOCS_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ command reports the bare version (e.g. `0.1.0`).
 
 ### Changed
 
+* Docs pages are now published only after a successful release, rebuilding from the published tag rather than in parallel on tag push. Each page footer and the home page display the release (or branch) they were built from.
+* Docs support dark mode: they follow the OS/browser color-scheme preference by default and expose a sun/moon toggle in the header (next to the GitHub link) that overrides and persists the choice.
+* The README's Documentation section now links directly to the hosted GitHub Pages docs.
+
 ## [0.1.0] - 2026-08-??
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ with `opencode-sandbox build` to upgrade (optionally pinning a specific version 
 
 ## Documentation
 
+The docs are also published to [GitHub Pages](https://inoio.github.io/opencode-sandbox/).
+
 | Topic                                         | Description                                            |
 |-----------------------------------------------|--------------------------------------------------------|
 | [Getting Started](/docs/getting-started.md)   | Installation, prerequisites, configuration, first run  |

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+# Docs build artefacts and dependencies
+/_site/
+/.bundle/
+/vendor/
+/_data/
+/Gemfile.lock

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,3 @@
+<span class="fs-2">
+  Docs built from release {{ site.data.version.release }}
+</span>

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,33 @@
+<script>
+(function () {
+  function saved() {
+    try {
+      var v = window.localStorage.getItem("jtd-theme");
+      return v === "dark" || v === "light" ? v : null;
+    } catch (e) {
+      return null;
+    }
+  }
+  function preferred() {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  function apply(scheme) {
+    var link = document.querySelector("link[rel='stylesheet']");
+    if (link) {
+      link.href = link.href.replace(/just-the-docs-(default|light|dark)\.css/, "just-the-docs-" + scheme + ".css");
+    }
+  }
+  var savedScheme = saved();
+  var initialScheme = savedScheme || preferred();
+  apply(initialScheme);
+  var mql = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+  if (mql && mql.addEventListener) {
+    mql.addEventListener("change", function (e) {
+      if (saved()) return;
+      apply(e.matches ? "dark" : "light");
+    });
+  }
+})();
+</script>

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,36 @@
+<button class="btn btn-outline" type="button" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="align-self: center; display: inline-flex; align-items: center; line-height: 1; padding: 0.15rem 0.35rem; margin-left: 0.5rem; margin-right: 0.5rem; cursor: pointer; box-shadow: none; background: transparent;">
+  <svg id="theme-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"></svg>
+</button>
+<script>
+(function () {
+  var btn = document.getElementById("theme-toggle");
+  var icon = document.getElementById("theme-icon");
+  var MOON = '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>';
+  var SUN = '<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>';
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  function current() {
+    var theme = (window.jtd && jtd.getTheme && jtd.getTheme()) || "default";
+    return theme === "dark" ? "dark" : "light";
+  }
+  function render() {
+    icon.innerHTML = current() === "dark" ? SUN : MOON;
+    btn.setAttribute("aria-label", current() === "dark" ? "Switch to light mode" : "Switch to dark mode");
+  }
+  btn.addEventListener("click", function () {
+    var from = current();
+    var next = from === "dark" ? "light" : "dark";
+    jtd.setTheme(next);
+    try {
+      window.localStorage.setItem("jtd-theme", next);
+    } catch (e) {
+      console.log("just-the-docs theme toggle: could not persist \"" + next + "\" to localStorage.jtd-theme");
+    }
+    render();
+  });
+  render();
+})();
+</script>

--- a/docs/_includes/nav_footer_custom.html
+++ b/docs/_includes/nav_footer_custom.html
@@ -1,0 +1,5 @@
+<footer class="site-footer">
+  <p class="text-small text-grey-dk-000 mb-0">
+    This site uses <a href="https://github.com/just-the-docs/just-the-docs">Just the Docs</a>.
+  </p>
+</footer>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ nav_order: 0
 
 # opencode-sandbox
 
+This documentation is built from release `{{ site.data.version.release }}`.
+
 Launch [opencode](https://github.com/anthropics/opencode) inside a nearly instant microsandbox VM with your project
 mounted at `/workspace`. Unleash your agents' full permissions in a disposable cage, so they can do their best work
 without ever roaming your host or ever learning your secrets.


### PR DESCRIPTION
- Trigger docs publishing on release (published) instead of tag push, and rebuild from the released tag so the correct docs are always served.
- Show the release/branch the docs were built from on the home page and in each page footer.
- Add dark mode that follows the OS color-scheme preference by default with a sun/moon toggle in the header that overrides and persists the choice.
- Link to the hosted GitHub Pages docs from the README Documentation section.
- Ignore docs build artefacts via docs/.gitignore.