### PR TITLE
fix(reprovision): host changes on secrets don't change their hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ command reports the bare version (e.g. `0.1.0`).
 
 ### Changed
 
-* Docs pages are now published only after a successful release, rebuilding from the published tag rather than in parallel on tag push. Each page footer and the home page display the release (or branch) they were built from.
-* Docs support dark mode: they follow the OS/browser color-scheme preference by default and expose a sun/moon toggle in the header (next to the GitHub link) that overrides and persists the choice.
-* The README's Documentation section now links directly to the hosted GitHub Pages docs.
+* Docs: Pages are now published only after a successful release, rebuilding from the published tag rather than in parallel on tag push. Each page footer and the home page display the release (or branch) they were built from.
+* Docs: Support for dark mode; follows the OS/browser color-scheme preference by default and expose a sun/moon toggle in the header (next to the GitHub link) that overrides and persists the choice.
+* Docs: The README's Documentation section now links directly to the hosted GitHub Pages docs.
+* Bugfix: A change to a secret's allowed hosts (or other secret properties such as placeholder) now triggers a VM recreate; previously only the secret value was part of the change hash, so host changes were silently ignored.
 
 ## [0.1.0] - 2026-08-??
 

--- a/internal/sandbox/reprovision/config_files.go
+++ b/internal/sandbox/reprovision/config_files.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
@@ -208,7 +209,10 @@ func EnvContentHash(env map[string]string) string {
 }
 
 // SecretsContentHash returns a SHA-256 hex digest of the secret entries.
-// Entries are sorted by EnvVar and hashed as "ENVVAR=VALUE" lines.
+// Entries are sorted by EnvVar and hashed as "ENVVAR=VALUE|HOSTS|PATTERNS|
+// PLACEHOLDER|TLS|VIOLATION" lines. Every field that microsandbox bakes into
+// the VM at creation is included so a change to any of them (not just the
+// value) triggers the VM recreate that applies it.
 func SecretsContentHash(entries []msbSdk.SecretEntry) string {
 	if entries == nil {
 		entries = []msbSdk.SecretEntry{}
@@ -224,7 +228,20 @@ func SecretsContentHash(entries []msbSdk.SecretEntry) string {
 	sort.Strings(envVars)
 	var b strings.Builder
 	for _, k := range envVars {
-		fmt.Fprintf(&b, "%s=%s\n", k, byEnv[k].Value)
+		e := byEnv[k]
+		tls := ""
+		if e.RequireTLS != nil {
+			tls = strconv.FormatBool(*e.RequireTLS)
+		}
+		fmt.Fprintf(&b, "%s=%s|%s|%s|%s|%s|%s\n",
+			k,
+			e.Value,
+			strings.Join(e.AllowHosts, ","),
+			strings.Join(e.AllowHostPatterns, ","),
+			e.Placeholder,
+			tls,
+			string(e.OnViolation),
+		)
 	}
 	h := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(h[:])

--- a/internal/sandbox/reprovision/config_hashes_test.go
+++ b/internal/sandbox/reprovision/config_hashes_test.go
@@ -50,6 +50,35 @@ func TestEnvChanged(t *testing.T) {
 	}
 }
 
+func TestSecretsContentHashIncludesHosts(t *testing.T) {
+	// A change to a secret's allowed hosts (with the same value) must produce
+	// a different hash so the launcher recreates the VM. See SecretsContentHash.
+	a := SecretsContentHash([]msbSdk.SecretEntry{
+		{EnvVar: "GITHUB_TOKEN", Value: "t", AllowHosts: []string{"github.com"}},
+	})
+	b := SecretsContentHash([]msbSdk.SecretEntry{
+		{EnvVar: "GITHUB_TOKEN", Value: "t", AllowHosts: []string{"api.github.com", "github.com"}},
+	})
+	if a == b {
+		t.Error("SecretsContentHash should differ when AllowHosts changes with the same value")
+	}
+}
+
+func TestSecretsContentHashIncludesOtherFields(t *testing.T) {
+	placeholder := "$GITHUB_TOKEN"
+	base := SecretsContentHash([]msbSdk.SecretEntry{{EnvVar: "A", Value: "1"}})
+	if got := SecretsContentHash([]msbSdk.SecretEntry{
+		{EnvVar: "A", Value: "1", AllowHostPatterns: []string{"*.github.com"}},
+	}); got == base {
+		t.Error("SecretsContentHash should differ when AllowHostPatterns changes")
+	}
+	if got := SecretsContentHash(
+		[]msbSdk.SecretEntry{{EnvVar: "A", Value: "1", Placeholder: placeholder}},
+	); got == base {
+		t.Error("SecretsContentHash should differ when Placeholder changes")
+	}
+}
+
 func TestSecretsChanged(t *testing.T) {
 	hash := SecretsContentHash([]msbSdk.SecretEntry{{EnvVar: "A", Value: "1"}})
 	if SecretsChanged(state.SecretState{Hash: hash}, []msbSdk.SecretEntry{{EnvVar: "A", Value: "1"}}) {

--- a/internal/sandbox/reprovision/config_hashes_test.go
+++ b/internal/sandbox/reprovision/config_hashes_test.go
@@ -65,17 +65,31 @@ func TestSecretsContentHashIncludesHosts(t *testing.T) {
 }
 
 func TestSecretsContentHashIncludesOtherFields(t *testing.T) {
-	placeholder := "$GITHUB_TOKEN"
-	base := SecretsContentHash([]msbSdk.SecretEntry{{EnvVar: "A", Value: "1"}})
-	if got := SecretsContentHash([]msbSdk.SecretEntry{
-		{EnvVar: "A", Value: "1", AllowHostPatterns: []string{"*.github.com"}},
-	}); got == base {
-		t.Error("SecretsContentHash should differ when AllowHostPatterns changes")
+	base := msbSdk.SecretEntry{EnvVar: "A", Value: "1"}
+	baseHash := SecretsContentHash([]msbSdk.SecretEntry{base})
+
+	boolPtr := func(v bool) *bool { return &v }
+	tests := []struct {
+		name   string
+		mutate func(e *msbSdk.SecretEntry)
+	}{
+		{"Value", func(e *msbSdk.SecretEntry) { e.Value = "2" }},
+		{"AllowHosts", func(e *msbSdk.SecretEntry) { e.AllowHosts = []string{"github.com"} }},
+		{"AllowHostPatterns", func(e *msbSdk.SecretEntry) { e.AllowHostPatterns = []string{"*.github.com"} }},
+		{"Placeholder", func(e *msbSdk.SecretEntry) { e.Placeholder = "$GITHUB_TOKEN" }},
+		{"RequireTLS true", func(e *msbSdk.SecretEntry) { e.RequireTLS = boolPtr(true) }},
+		{"RequireTLS false", func(e *msbSdk.SecretEntry) { e.RequireTLS = boolPtr(false) }},
+		{"OnViolation", func(e *msbSdk.SecretEntry) { e.OnViolation = msbSdk.ViolationActionBlock }},
 	}
-	if got := SecretsContentHash(
-		[]msbSdk.SecretEntry{{EnvVar: "A", Value: "1", Placeholder: placeholder}},
-	); got == base {
-		t.Error("SecretsContentHash should differ when Placeholder changes")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := base
+			tt.mutate(&e)
+			if got := SecretsContentHash([]msbSdk.SecretEntry{e}); got == baseHash {
+				t.Errorf("SecretsContentHash should differ when %s changes", tt.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Changing hosts on secrets did not trigger reprovisioning of the VM.

Now, all fields of the SecretEntry are fed into the hash.
