### PR TITLE
Fix opencode links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Security](https://img.shields.io/badge/security-policy-purple.svg)](SECURITY.md)
 [![Docs](https://img.shields.io/badge/docs-github--pages-blue)](https://inoio.github.io/opencode-sandbox/)
 
-opencode-sandbox launches [opencode](https://github.com/anthropics/opencode) inside an isolated Linux VM backed
+opencode-sandbox launches [opencode](https://github.com/anomalyco/opencode) inside an isolated Linux VM backed
 by [microsandbox](https://github.com/superradcompany/microsandbox). Each project gets a persistent project VM — shared
 across sessions with a configurable auto-stop policy (see [Configuration](/docs/configuration.md) and
 [Sandboxes](/docs/sandboxes.md)). The VM has your project mounted as `/workspace`, a persistent home directory

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 ## What is opencode-sandbox?
 
-opencode-sandbox is a launcher that runs [opencode](https://github.com/anthropics/opencode) inside an isolated microsandbox
+opencode-sandbox is a launcher that runs [opencode](https://github.com/anomalyco/opencode) inside an isolated microsandbox
 VM powered by [microsandbox](https://github.com/superradcompany/microsandbox). Each project gets a persistent VM
 identified by its git remote URL — first boot creates a fresh VM, subsequent runs connect to or start the existing one.
 The VM has your project bound as `/workspace`, a persistent home directory volume, and access to a curated toolchain.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ nav_order: 0
 
 This documentation is built from release `{{ site.data.version.release }}`.
 
-Launch [opencode](https://github.com/anthropics/opencode) inside a nearly instant microsandbox VM with your project
+Launch [opencode](https://github.com/anomalyco/opencode) inside a nearly instant microsandbox VM with your project
 mounted at `/workspace`. Unleash your agents' full permissions in a disposable cage, so they can do their best work
 without ever roaming your host or ever learning your secrets.
 


### PR DESCRIPTION
Opencode is provided by anomalyco and not Anthropic, this is fixed in the Readme, docs home and getting started pages. 
