### PR TITLE
feat(config): configurable host bind mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ command reports the bare version (e.g. `0.1.0`).
 - Docs: New `Recipes` page with a hands-on how-to for connecting Opencode Desktop via `run --serve-only`; moved out of the README. The comparison matrix also names Docker Sandboxes and adds a "Why not just use Docker Sandboxes?" callout.
 - Docs: `Recipes` is now a parent overview page (with `has_children`); the Connect Opencode Desktop recipe lives on a nested child page, ready for more recipes to be added.
 - Docs: Sidebar submenus are expanded by default via a small script in `docs/_includes/head_custom.html`.
+- Configurable host-directory bind mounts (`mounts`), including `~/` source expansion and read-only mounts. Mount changes are tracked via a persisted fingerprint and recreate the project VM.
 
 ### Changed
 

--- a/cmd/opencode-sandbox/cli_run_options_test.go
+++ b/cmd/opencode-sandbox/cli_run_options_test.go
@@ -377,3 +377,49 @@ func TestExtractRunOptionsNetworkInvalid(t *testing.T) {
 		t.Fatal("expected error for invalid --network profile")
 	}
 }
+
+// Configured mounts are resolved into RunOptions, keyed by guest path.
+func TestExtractRunOptionsResolvesMounts(t *testing.T) {
+	ui := &termio.Mock{}
+	source := t.TempDir()
+	lc := launcherconfig.Config{Mounts: options.Mounts{
+		"/home/dev/.m2": {Source: source},
+	}}
+	cmd := buildCommandWithLauncherConfig(ui, lc)
+
+	opts, err := extractRunOptions(cmd, ui)
+	if err != nil {
+		t.Fatalf("extractRunOptions: %v", err)
+	}
+	mount, ok := opts.Mounts["/home/dev/.m2"]
+	if !ok {
+		t.Fatalf("Mounts = %+v; want a /home/dev/.m2 entry", opts.Mounts)
+	}
+	if mount.Source != source {
+		t.Errorf("Source = %q; want %q", mount.Source, source)
+	}
+}
+
+// An invalid mount must fail the command rather than silently starting a VM
+// without the mount.
+func TestExtractRunOptionsRejectsInvalidMount(t *testing.T) {
+	cases := []struct {
+		name  string
+		mount options.Mounts
+	}{
+		{"missing source", options.Mounts{"/home/dev/.m2": {Source: "/definitely/not/here"}}},
+		{"reserved target", options.Mounts{"/workspace": {Source: "/tmp"}}},
+		{"relative target", options.Mounts{"relative": {Source: "/tmp"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := &termio.Mock{}
+			lc := launcherconfig.Config{Mounts: tc.mount}
+			cmd := buildCommandWithLauncherConfig(ui, lc)
+
+			if _, err := extractRunOptions(cmd, ui); err == nil {
+				t.Fatal("expected extractRunOptions to fail")
+			}
+		})
+	}
+}

--- a/cmd/opencode-sandbox/commands.go
+++ b/cmd/opencode-sandbox/commands.go
@@ -50,6 +50,10 @@ func extractRunOptions(cmd *cobra.Command, ui termio.UI) (options.RunOptions, er
 		opts.WorkspaceQuota = r.WorkspaceQuota()
 		opts.ReapPolicy = options.NewReapPolicy(r.AutoStopOnActiveSessions(), r.AutoStopMaxSessionRetries())
 		opts.IdleTimeout = r.IdleTimeout()
+		opts.Mounts, err = options.ResolveBindMounts(r.Mounts())
+		if err != nil {
+			return options.RunOptions{}, err
+		}
 	}
 
 	// CLI flag wins over resolver/env/config; otherwise use the resolver's

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,24 +61,25 @@ Configuration is resolved in this order (later entries override earlier ones):
 
 ## Configuration file
 
-| Field                           | Corresponding CLI flag | Description                                                                                                                                                                                                               |
-|---------------------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `yes`                           | `--yes` / `-y`         | Assume yes to all prompts                                                                                                                                                                                                 |
-| `quiet`                         | `--quiet` / `-q`       | Suppress stdout output                                                                                                                                                                                                    |
-| `log-level`                     | `--log-level` / `-l`   | Minimum log level to show on the console: `error`, `warning`, `info`, `verbose` (default `info`)                                                                                                                          |
-| `cpus`                          | `--cpus` / `-c`        | Number of vCPUs for the VM                                                                                                                                                                                                |
-| `memory`                        | `--memory` / `-m`      | Memory limit (e.g. `8G`)                                                                                                                                                                                                  |
-| `disk-size`                     | `--disk-size`          | Project VM root disk size (e.g. `16G`). Empty = microsandbox runtime default (~4 GiB). Applied at VM creation; a change triggers recreation. An invalid value is rejected with an error.                                  |
-| `tmp-size`                      | `--tmp-size`           | Size of `/tmp` tmpfs in the sandbox. An invalid value is rejected with an error.                                                                                                                                          |
-| `workspace-quota`               | `--workspace-quota`    | Guest-write quota for the `/workspace` bind mount (e.g. `32G`), bounding writes on top of the host repo. Default `16G`. Applied at VM creation; a change triggers recreation. An invalid value is rejected with an error. |
-| `auto-prune-age`                | —                      | Auto-prune threshold, runs before every command (default: 30d, only in config). Applies to VMs, volumes, and images alike.                                                                                                |
-| `manual-prune-age`              | `--age`                | Default prune age threshold for `prune`, `image prune`, `volume prune`, and `sandbox prune`                                                                                                                               |
-| `auto-stop-on-active-sessions`  | —                      | Stop VM immediately on client detach without waiting for active sessions (default: false, only in config; `busy` sessions are never cut off)                                                                              |
-| `auto-stop-timeout`             | —                      | Idle timeout after last client detaches (default: 10s, only in config)                                                                                                                                                    |
-| `auto-stop-max-session-retries` | —                      | Retries to tolerate for a session stuck in `retry` before stopping (default: 10, only in config)                                                                                                                          |
-| `network.profile`               | `--network`            | Network profile: `public`, `private`, `host`, or `none` (see [Networking](#networking))                                                                                                                                   |
-| `network.egress-allow`          | —                      | Egress destinations to allow: `host`, a CIDR, or a `.suffix` (see [Networking](#networking))                                                                                                                              |
-| `network.egress-deny`           | —                      | Egress carve-outs, emitted before allow rules (see [Networking](#networking))                                                                                                                                             |
+| Field                           | Corresponding CLI flag   | Description                                                                                                                                                                                                               |
+|---------------------------------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `yes`                           | `--yes` / `-y`           | Assume yes to all prompts                                                                                                                                                                                                 |
+| `quiet`                         | `--quiet` / `-q`         | Suppress stdout output                                                                                                                                                                                                    |
+| `log-level`                     | `--log-level` / `-l`     | Minimum log level to show on the console: `error`, `warning`, `info`, `verbose` (default `info`)                                                                                                                          |
+| `cpus`                          | `--cpus` / `-c`          | Number of vCPUs for the VM                                                                                                                                                                                                |
+| `memory`                        | `--memory` / `-m`        | Memory limit (e.g. `8G`)                                                                                                                                                                                                  |
+| `disk-size`                     | `--disk-size`            | Project VM root disk size (e.g. `16G`). Empty = microsandbox runtime default (~4 GiB). Applied at VM creation; a change triggers recreation. An invalid value is rejected with an error.                                  |
+| `tmp-size`                      | `--tmp-size`             | Size of `/tmp` tmpfs in the sandbox. An invalid value is rejected with an error.                                                                                                                                          |
+| `workspace-quota`               | `--workspace-quota`      | Guest-write quota for the `/workspace` bind mount (e.g. `32G`), bounding writes on top of the host repo. Default `16G`. Applied at VM creation; a change triggers recreation. An invalid value is rejected with an error. |
+| `auto-prune-age`                | —                        | Auto-prune threshold, runs before every command (default: 30d, only in config). Applies to VMs, volumes, and images alike.                                                                                                |
+| `manual-prune-age`              | `--age`                  | Default prune age threshold for `prune`, `image prune`, `volume prune`, and `sandbox prune`                                                                                                                               |
+| `auto-stop-on-active-sessions`  | —                        | Stop VM immediately on client detach without waiting for active sessions (default: false, only in config; `busy` sessions are never cut off)                                                                              |
+| `auto-stop-timeout`             | —                        | Idle timeout after last client detaches (default: 10s, only in config)                                                                                                                                                    |
+| `auto-stop-max-session-retries` | —                        | Retries to tolerate for a session stuck in `retry` before stopping (default: 10, only in config)                                                                                                                          |
+| `network.profile`               | `--network`              | Network profile: `public`, `private`, `host`, or `none` (see [Networking](#networking))                                                                                                                                   |
+| `network.egress-allow`          | —                        | Egress destinations to allow: `host`, a CIDR, or a `.suffix` (see [Networking](#networking))                                                                                                                              |
+| `network.egress-deny`           | —                        | Egress carve-outs, emitted before allow rules (see [Networking](#networking))                                                                                                                                             
+| `mounts`                        | —                        | Additional host directories mounted into the VM (see [Host bind mounts](#host-bind-mounts))                                                                                                                               |
 
 Example `~/.config/opencode-sandbox/config.yaml`:
 
@@ -97,6 +98,8 @@ network:
   profile: public
   egress-allow: []
   egress-deny: []
+mounts:
+  /home/dev/.m2: ~/.m2
 ```
 
 ### Duration fields
@@ -133,6 +136,7 @@ session. The change type determines the mechanism used to apply the new settings
 | `image`           | VM recreate    | VM is recreated with the new root image. Home volume is preserved.                                       |
 | `home volume`     | VM recreate    | After `volume migrate`/`reset`, the new home volume is mounted by recreating the VM; the mount is baked in at creation. |
 | `network`         | VM recreate    | Network policy is baked in at VM creation, so a change recreates the VM. Home volume is preserved.        |
+| `mounts`          | VM recreate    | Host bind mounts are baked in at VM creation.                                                           |
 
 When **no other client** is attached, config changes apply immediately.
 
@@ -212,6 +216,26 @@ network:
   egress-allow: []          # host, CIDR, or .suffix
   egress-deny: []           # carve-outs; emitted before allow rules
 ```
+
+## Host bind mounts
+
+The `mounts` map exposes additional host directories inside the sandbox. Each key is an absolute guest target and its
+value is either the host source directory or a mapping with `source` and optional `readonly`. Sources may be absolute or
+start with `~/`. Mounts are writable by default; set `readonly: true` when the sandbox must not modify the host directory.
+
+```yaml
+mounts:
+  /home/dev/.m2: ~/.m2
+  /home/dev/reference:
+    source: /opt/company/reference
+    readonly: true
+```
+
+Configured source directories must already exist on the host and must be directories. The managed mount targets
+`/home/dev`, `/workspace`, and `/tmp` cannot be replaced, and a target may not shadow a parent of them. Nesting a mount
+inside `/workspace` or `/tmp` is rejected because it would hide managed content; nesting inside `/home/dev` is allowed
+and is the common case. A mount configuration change recreates the project VM. Writable mounts let sandbox processes
+modify host files directly, so only mount directories whose contents may be changed by sandboxed tools.
 
 ## Per-slug configuration
 

--- a/internal/sandbox/options/mounts.go
+++ b/internal/sandbox/options/mounts.go
@@ -1,0 +1,206 @@
+package options
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Guest mount points that opencode-sandbox manages itself. They are fixed by
+// the project VM layout and shared by the packages that build or inspect it.
+const (
+	// VMHomeDir is the sandbox home mount point (a named volume).
+	VMHomeDir = "/home/dev"
+	// WorkspaceMountPath is the mount point of the host project bind mount.
+	WorkspaceMountPath = "/workspace"
+	// TmpMountPath is the mount point used for the sandbox tmpfs.
+	TmpMountPath = "/tmp"
+)
+
+// BindMount maps a host directory into the sandbox at an absolute guest path.
+type BindMount struct {
+	Source   string `mapstructure:"source"`
+	Readonly bool   `mapstructure:"readonly"`
+}
+
+// Mounts maps absolute guest target paths to host bind-mount settings.
+type Mounts map[string]BindMount
+
+const (
+	mountFieldSource   = "source"
+	mountFieldReadonly = "readonly"
+)
+
+// DecodeMounts parses the launcher config's short and long mount forms.
+func DecodeMounts(raw any) (Mounts, error) {
+	if raw == nil {
+		return Mounts{}, nil
+	}
+	entries, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("mounts must be a mapping, got %T", raw)
+	}
+	mounts := make(Mounts, len(entries))
+	for target, rawEntry := range entries {
+		mount, err := decodeMount(rawEntry)
+		if err != nil {
+			return nil, fmt.Errorf("decode mount %q: %w", target, err)
+		}
+		mounts[target] = mount
+	}
+	return mounts, nil
+}
+
+func decodeMount(raw any) (BindMount, error) {
+	switch entry := raw.(type) {
+	case string:
+		return BindMount{Source: entry, Readonly: false}, nil
+	case map[string]any:
+		var mount BindMount
+		for key, value := range entry {
+			switch key {
+			case mountFieldSource:
+				source, ok := value.(string)
+				if !ok {
+					return BindMount{}, errors.New("source must be a string")
+				}
+				mount.Source = source
+			case mountFieldReadonly:
+				readonly, ok := value.(bool)
+				if !ok {
+					return BindMount{}, errors.New("readonly must be a boolean")
+				}
+				mount.Readonly = readonly
+			default:
+				return BindMount{}, fmt.Errorf("unknown field %q", key)
+			}
+		}
+		return mount, nil
+	default:
+		return BindMount{}, fmt.Errorf("value must be a source string or mapping, got %T", raw)
+	}
+}
+
+// managedMountTargets are the guest paths opencode-sandbox mounts itself. A
+// configured mount may not replace them, nor shadow a parent of them.
+//
+//nolint:gochecknoglobals // package-level constant slice
+var managedMountTargets = []string{VMHomeDir, WorkspaceMountPath, TmpMountPath}
+
+// exclusiveMountTargets are managed mounts whose contents must stay visible,
+// so nesting a configured mount inside them is rejected as well. The home
+// volume is absent on purpose: mounting into it (e.g. /home/dev/.m2) is the
+// primary use case.
+//
+//nolint:gochecknoglobals // package-level constant slice
+var exclusiveMountTargets = []string{WorkspaceMountPath, TmpMountPath}
+
+// ResolveBindMounts expands host paths and validates configured bind mounts,
+// returning them keyed by cleaned guest path.
+func ResolveBindMounts(mounts Mounts) (Mounts, error) {
+	resolved := make(map[string]BindMount, len(mounts))
+	for rawTarget, mount := range mounts {
+		target, err := resolveMountTarget(rawTarget)
+		if err != nil {
+			return nil, err
+		}
+		source, err := resolveMountSource(mount.Source)
+		if err != nil {
+			return nil, fmt.Errorf("mount %q: %w", target, err)
+		}
+		if _, exists := resolved[target]; exists {
+			return nil, fmt.Errorf("duplicate mount target %q", target)
+		}
+		mount.Source = source
+		resolved[target] = mount
+	}
+	return resolved, nil
+}
+
+// Fingerprint returns a stable SHA-256 hex digest of the resolved mounts, for
+// detecting changes across runs. Mounts are baked into the VM at creation
+// time, so a differing fingerprint requires recreating the VM.
+func Fingerprint(mounts Mounts) string {
+	lines := make([]string, 0, len(mounts))
+	for target, mount := range mounts {
+		lines = append(lines, fmt.Sprintf("%s=%s,ro=%t", target, mount.Source, mount.Readonly))
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// MountTargets returns the configured guest paths in sorted order.
+func MountTargets(mounts Mounts) []string {
+	targets := make([]string, 0, len(mounts))
+	for target := range mounts {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+// resolveMountTarget validates a guest mount path and returns it cleaned.
+func resolveMountTarget(target string) (string, error) {
+	if !filepath.IsAbs(target) {
+		return "", fmt.Errorf("mount target %q must be an absolute path", target)
+	}
+	clean := filepath.Clean(target)
+	if clean == "/" {
+		return "", errors.New(`mount target "/" is not allowed`)
+	}
+	for _, managed := range managedMountTargets {
+		if clean == managed || isWithin(managed, clean) {
+			return "", fmt.Errorf("mount target %q conflicts with managed mount %q", target, managed)
+		}
+	}
+	for _, exclusive := range exclusiveMountTargets {
+		if isWithin(clean, exclusive) {
+			return "", fmt.Errorf("mount target %q would shadow content of managed mount %q", target, exclusive)
+		}
+	}
+	return clean, nil
+}
+
+// resolveMountSource expands a host source path and verifies it is a directory.
+func resolveMountSource(source string) (string, error) {
+	path, err := expandHome(source)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("source %q must be a directory", path)
+	}
+	return path, nil
+}
+
+// isWithin reports whether path lies inside base.
+func isWithin(path, base string) bool {
+	return strings.HasPrefix(path, base+string(filepath.Separator))
+}
+
+func expandHome(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("source must not be empty")
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("source %q must be absolute or start with ~/", path)
+	}
+	return filepath.Clean(path), nil
+}

--- a/internal/sandbox/options/mounts_test.go
+++ b/internal/sandbox/options/mounts_test.go
@@ -1,0 +1,221 @@
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDecodeMountsShortAndLongForms(t *testing.T) {
+	got, err := DecodeMounts(map[string]any{
+		"/home/dev/.m2": "~/.m2",
+		"/home/dev/ref": map[string]any{
+			"source":   "/opt/company/reference",
+			"readonly": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("DecodeMounts: %v", err)
+	}
+	if mount := got["/home/dev/.m2"]; mount.Source != "~/.m2" || mount.Readonly {
+		t.Errorf("short mount = %+v", mount)
+	}
+	if mount := got["/home/dev/ref"]; mount.Source != "/opt/company/reference" || !mount.Readonly {
+		t.Errorf("long mount = %+v", mount)
+	}
+}
+
+func TestDecodeMountsRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  any
+	}{
+		{"not a mapping", []string{"~/.m2"}},
+		{"invalid value", map[string]any{"/home/dev/.m2": true}},
+		{"source not string", map[string]any{"/home/dev/.m2": map[string]any{"source": true}}},
+		{"readonly not boolean", map[string]any{"/home/dev/.m2": map[string]any{"readonly": "yes"}}},
+		{"unknown field", map[string]any{"/home/dev/.m2": map[string]any{"read-only": true}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeMounts(tc.raw); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestDecodeMountsNil(t *testing.T) {
+	got, err := DecodeMounts(nil)
+	if err != nil {
+		t.Fatalf("DecodeMounts: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("DecodeMounts(nil) = %+v, want empty", got)
+	}
+}
+
+func TestResolveBindMountsExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".m2")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	got, err := ResolveBindMounts(Mounts{
+		"/home/dev/.m2": {Source: "~/.m2"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveBindMounts: %v", err)
+	}
+	mount, ok := got["/home/dev/.m2"]
+	if !ok {
+		t.Fatalf("missing resolved mount: %+v", got)
+	}
+	if mount.Source != source {
+		t.Errorf("source = %q, want %q", mount.Source, source)
+	}
+	if mount.Readonly {
+		t.Error("expected a writable mount by default")
+	}
+}
+
+// TestResolveBindMountsExpandsBareTilde guards the `source: ~` form, where
+// TrimPrefix must not leave the tilde in place (which would yield $HOME/~).
+func TestResolveBindMountsExpandsBareTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := ResolveBindMounts(Mounts{"/home/dev/host": {Source: "~"}})
+	if err != nil {
+		t.Fatalf("ResolveBindMounts: %v", err)
+	}
+	if got["/home/dev/host"].Source != home {
+		t.Errorf("source = %q, want %q", got["/home/dev/host"].Source, home)
+	}
+}
+
+func TestResolveBindMountsKeepsReadonly(t *testing.T) {
+	got, err := ResolveBindMounts(Mounts{
+		"/home/dev/ref": {Source: t.TempDir(), Readonly: true},
+	})
+	if err != nil {
+		t.Fatalf("ResolveBindMounts: %v", err)
+	}
+	if !got["/home/dev/ref"].Readonly {
+		t.Error("expected readonly to be preserved")
+	}
+}
+
+func TestResolveBindMountsCleansTarget(t *testing.T) {
+	got, err := ResolveBindMounts(Mounts{
+		"/home/dev/./cache/": {Source: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("ResolveBindMounts: %v", err)
+	}
+	if _, ok := got["/home/dev/cache"]; !ok {
+		t.Errorf("expected cleaned target /home/dev/cache, got %+v", got)
+	}
+}
+
+func TestResolveBindMountsRejectsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "settings.xml")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		mounts Mounts
+	}{
+		{"reserved workspace", Mounts{"/workspace": {Source: dir}}},
+		{"reserved tmp", Mounts{"/tmp": {Source: dir}}},
+		{"reserved home", Mounts{"/home/dev": {Source: dir}}},
+		{"ancestor of home", Mounts{"/home": {Source: dir}}},
+		{"root target", Mounts{"/": {Source: dir}}},
+		{"nested in workspace", Mounts{"/workspace/vendor": {Source: dir}}},
+		{"nested in tmp", Mounts{"/tmp/cache": {Source: dir}}},
+		{"relative target", Mounts{"home/dev/.m2": {Source: dir}}},
+		{"empty source", Mounts{"/home/dev/.m2": {Source: ""}}},
+		{"relative source", Mounts{"/home/dev/.m2": {Source: "relative/path"}}},
+		{"missing source", Mounts{"/home/dev/.m2": {Source: filepath.Join(dir, "nope")}}},
+		{"source is a file", Mounts{"/home/dev/.m2": {Source: file}}},
+		{"duplicate target", Mounts{"/home/dev/.m2": {Source: dir}, "/home/dev/./.m2": {Source: dir}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ResolveBindMounts(tc.mounts); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+// TestResolveBindMountsAllowsNestedHomeMount documents that mounting into the
+// home volume is supported; it is the primary use case (e.g. ~/.m2).
+func TestResolveBindMountsAllowsNestedHomeMount(t *testing.T) {
+	if _, err := ResolveBindMounts(Mounts{
+		"/home/dev/.m2": {Source: t.TempDir()},
+	}); err != nil {
+		t.Fatalf("expected a nested home mount to be allowed: %v", err)
+	}
+}
+
+func TestFingerprintIsStableAndOrderIndependent(t *testing.T) {
+	a := Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2"},
+		"/home/dev/ref": {Source: "/host/ref", Readonly: true},
+	}
+	b := Mounts{
+		"/home/dev/ref": {Source: "/host/ref", Readonly: true},
+		"/home/dev/.m2": {Source: "/host/.m2"},
+	}
+	if Fingerprint(a) != Fingerprint(b) {
+		t.Error("fingerprint must not depend on map iteration order")
+	}
+	if Fingerprint(nil) == Fingerprint(a) {
+		t.Error("empty and non-empty mount sets must differ")
+	}
+}
+
+func TestFingerprintDetectsFieldChanges(t *testing.T) {
+	base := Mounts{"/home/dev/.m2": {Source: "/host/.m2"}}
+	readonly := Mounts{"/home/dev/.m2": {Source: "/host/.m2", Readonly: true}}
+	otherSource := Mounts{"/home/dev/.m2": {Source: "/host/other"}}
+	otherTarget := Mounts{"/home/dev/m2": {Source: "/host/.m2"}}
+
+	if Fingerprint(base) == Fingerprint(readonly) {
+		t.Error("readonly change must alter the fingerprint")
+	}
+	if Fingerprint(base) == Fingerprint(otherSource) {
+		t.Error("source change must alter the fingerprint")
+	}
+	if Fingerprint(base) == Fingerprint(otherTarget) {
+		t.Error("target change must alter the fingerprint")
+	}
+}
+
+func TestMountTargetsSorted(t *testing.T) {
+	got := MountTargets(Mounts{
+		"/home/dev/z": {},
+		"/home/dev/a": {},
+	})
+	if len(got) != 2 || got[0] != "/home/dev/a" || got[1] != "/home/dev/z" {
+		t.Errorf("MountTargets = %v, want sorted", got)
+	}
+}
+
+// TestResolveBindMountsHomeDirUnresolvable covers the branch where the host
+// home directory cannot be determined, so `~/` cannot be expanded.
+func TestResolveBindMountsHomeDirUnresolvable(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	if _, err := ResolveBindMounts(Mounts{
+		"/home/dev/.m2": {Source: "~/.m2"},
+	}); err == nil {
+		t.Fatal("expected an error when the home directory cannot be resolved")
+	}
+}

--- a/internal/sandbox/options/options.go
+++ b/internal/sandbox/options/options.go
@@ -34,6 +34,8 @@ type RunOptions struct {
 	// Network is the resolved egress policy for the project VM. The zero value
 	// (Empty) means no policy is set and the default public profile applies.
 	Network network.Policy
+	// Mounts are additional host directories bind-mounted at absolute guest paths.
+	Mounts Mounts
 	// OpenCodeVersion pins the opencode version baked into the runner image on
 	// rebuild. Empty means resolve the latest at build time.
 	OpenCodeVersion string

--- a/internal/sandbox/reprovision/config_files.go
+++ b/internal/sandbox/reprovision/config_files.go
@@ -19,6 +19,7 @@ import (
 	config "github.com/inoio/opencode-sandbox/internal/opencodeconfig"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 	"github.com/inoio/opencode-sandbox/internal/termio"
 
@@ -53,7 +54,7 @@ func parseKeyValueLines(data string, onLine func(key, value string) error) error
 
 // VMHomeDir is the sandbox home mount point. It is fixed by the project VM
 // layout regardless of the configured runtime user.
-const VMHomeDir = "/home/dev"
+const VMHomeDir = options.VMHomeDir
 
 // OpenCodeConfigPath returns the VM path where the merged opencode config is
 // provisioned.
@@ -117,10 +118,10 @@ func LoadConfigFiles(userConfigDir string, ui termio.UI) (*ConfigFiles, error) {
 }
 
 // tmpMountPath is the mount point used for the sandbox tmpfs.
-const tmpMountPath = "/tmp"
+const tmpMountPath = options.TmpMountPath
 
 // workspaceMountPath is the mount point used for the host bind mount.
-const workspaceMountPath = "/workspace"
+const workspaceMountPath = options.WorkspaceMountPath
 
 // ReadVMConfig reads the given absolute VM paths, returning a map of path to
 // content for files that exist.
@@ -319,5 +320,27 @@ func BuildNetworkState(desired network.Policy) state.NetworkState {
 	return state.NetworkState{
 		Hash:  desired.Fingerprint(),
 		Names: []string{string(desired.Profile)},
+	}
+}
+
+// MountsChanged reports whether the applied mount state differs from the
+// desired host bind mounts, comparing content fingerprints. The comparison is
+// fingerprint-based because the microsandbox SDK does not round-trip volumes
+// when reading back an existing VM, so the live config cannot be inspected. A
+// zero-value applied state indicates "no persisted state yet" (first run or a
+// VM created before mounts existed); it is only considered "changed" when
+// mounts are actually configured.
+func MountsChanged(applied state.MountState, desired options.Mounts) bool {
+	if applied.Hash == "" {
+		return len(desired) > 0
+	}
+	return applied.Hash != options.Fingerprint(desired)
+}
+
+// BuildMountState computes the fingerprint for the desired host bind mounts.
+func BuildMountState(desired options.Mounts) state.MountState {
+	return state.MountState{
+		Hash:  options.Fingerprint(desired),
+		Names: options.MountTargets(desired),
 	}
 }

--- a/internal/sandbox/reprovision/config_hashes_test.go
+++ b/internal/sandbox/reprovision/config_hashes_test.go
@@ -6,6 +6,7 @@ import (
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
 
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 )
 
@@ -154,5 +155,51 @@ func TestBuildNetworkState(t *testing.T) {
 	}
 	if len(st.Names) != 1 || st.Names[0] != string(network.ProfileNone) {
 		t.Errorf("BuildNetworkState.Names = %v, want [none]", st.Names)
+	}
+}
+
+func TestMountsChanged(t *testing.T) {
+	desired := options.Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2"},
+	}
+	applied := BuildMountState(desired)
+
+	if MountsChanged(applied, desired) {
+		t.Error("MountsChanged with identical mounts should be false")
+	}
+	if !MountsChanged(applied, nil) {
+		t.Error("MountsChanged after removing all mounts should be true")
+	}
+	if !MountsChanged(applied, options.Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2", Readonly: true},
+	}) {
+		t.Error("MountsChanged with a flipped readonly flag should be true")
+	}
+}
+
+// TestMountsChangedEmptyAppliedState covers VMs created before mounts existed:
+// no persisted fingerprint must only count as changed when mounts are set.
+func TestMountsChangedEmptyAppliedState(t *testing.T) {
+	if MountsChanged(state.MountState{}, nil) {
+		t.Error("MountsChanged with no persisted state and no mounts should be false")
+	}
+	if !MountsChanged(state.MountState{}, options.Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2"},
+	}) {
+		t.Error("MountsChanged with no persisted state and configured mounts should be true")
+	}
+}
+
+func TestBuildMountState(t *testing.T) {
+	desired := options.Mounts{
+		"/home/dev/z": {Source: "/host/z"},
+		"/home/dev/a": {Source: "/host/a"},
+	}
+	st := BuildMountState(desired)
+	if st.Hash != options.Fingerprint(desired) {
+		t.Errorf("BuildMountState.Hash = %q, want %q", st.Hash, options.Fingerprint(desired))
+	}
+	if len(st.Names) != 2 || st.Names[0] != "/home/dev/a" || st.Names[1] != "/home/dev/z" {
+		t.Errorf("BuildMountState.Names = %v, want sorted targets", st.Names)
 	}
 }

--- a/internal/sandbox/reprovision/coverage_test.go
+++ b/internal/sandbox/reprovision/coverage_test.go
@@ -279,7 +279,7 @@ func TestDiskMiBOr0NilRootDisk(t *testing.T) {
 // formatting.
 func TestPlanReconfigDiskChangeWithNilRootDisk(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{Image: "img"}
-	plan := PlanReconfig(cfg, "img", options.RunOptions{DiskSize: "8G"}, false, false, false, false, "")
+	plan := PlanReconfig(cfg, "img", options.RunOptions{DiskSize: "8G"}, ChangeFlags{}, "")
 	if !plan.Recreate {
 		t.Fatal("expected recreate on disk size change with nil RootDisk")
 	}

--- a/internal/sandbox/reprovision/plan.go
+++ b/internal/sandbox/reprovision/plan.go
@@ -14,6 +14,7 @@ import (
 
 const changeLabelPublishedPorts = "published port(s)"
 const changeLabelNetworkPolicy = "network policy"
+const changeLabelBindMounts = "host bind mounts"
 
 // Change describes one changed setting for prompt display. Values are
 // shown for simple sizes/counts; env/secrets/config carry labels only (Old/New empty).
@@ -62,6 +63,18 @@ func configChangeList(changes []Change) string {
 	return strings.Join(lines, "\n")
 }
 
+// ChangeFlags carries the change detections that PlanReconfig cannot derive
+// from the live VM config, because the microsandbox SDK does not round-trip
+// these settings when reading an existing VM back. Each flag is computed by
+// comparing a persisted fingerprint against the desired state.
+type ChangeFlags struct {
+	Env            bool
+	Secrets        bool
+	Network        bool
+	Mounts         bool
+	OpenCodeConfig bool
+}
+
 // PlanReconfig computes the reconfiguration plan given the current VM config
 // and the desired state. Returns a nil Plan when there is no existing config
 // (first creation) or nothing needs to change.
@@ -69,7 +82,7 @@ func PlanReconfig( //nolint:gocognit,gocyclo,cyclop,funlen // core planner, cogn
 	cfg *msbSdk.SandboxConfig,
 	imageRef string,
 	opts options.RunOptions,
-	envChanged, secretsChanged, networkChanged, opencodeConfigChanged bool,
+	flags ChangeFlags,
 	homeVol string,
 ) *Plan {
 	d := &Plan{} //nolint:exhaustruct // fields zeroed intentionally
@@ -115,6 +128,16 @@ func PlanReconfig( //nolint:gocognit,gocyclo,cyclop,funlen // core planner, cogn
 			)
 		}
 	}
+	// Host bind mounts are baked into the VM at creation time. The comparison
+	// is fingerprint-based (MountsChanged) for the same reason as the network
+	// policy: the SDK does not round-trip volumes when reading a VM back.
+	if flags.Mounts {
+		d.Recreate = true
+		d.Changes = append(
+			d.Changes,
+			Change{Label: changeLabelBindMounts}, //nolint:exhaustruct // label-only for change reporting
+		)
+	}
 	if wantDisk, ok := options.ParseMemoryOK(opts.DiskSize); ok {
 		if cfg.RootDisk == nil || cfg.RootDisk.SizeMiB != wantDisk {
 			d.Recreate = true
@@ -148,7 +171,7 @@ func PlanReconfig( //nolint:gocognit,gocyclo,cyclop,funlen // core planner, cogn
 	// recreate (same tier as env/secrets/ports). The comparison is based on a
 	// persisted fingerprint (NetworkChanged), because the microsandbox SDK does
 	// not round-trip the network config when reading back an existing VM.
-	if networkChanged {
+	if flags.Network {
 		d.Recreate = true
 		d.Changes = append(
 			d.Changes,
@@ -156,15 +179,15 @@ func PlanReconfig( //nolint:gocognit,gocyclo,cyclop,funlen // core planner, cogn
 		)
 	}
 
-	if !d.Recreate && (envChanged || secretsChanged) {
+	if !d.Recreate && (flags.Env || flags.Secrets) {
 		d.Recreate = true
-		if envChanged {
+		if flags.Env {
 			d.Changes = append(
 				d.Changes,
 				Change{Label: "environment variables"}, //nolint:exhaustruct // label-only for change reporting
 			)
 		}
-		if secretsChanged {
+		if flags.Secrets {
 			d.Changes = append(
 				d.Changes,
 				Change{Label: "secrets"}, //nolint:exhaustruct // label-only for change reporting
@@ -174,7 +197,7 @@ func PlanReconfig( //nolint:gocognit,gocyclo,cyclop,funlen // core planner, cogn
 
 	// opencode config changes are picked up by restarting the opencode daemon;
 	// a full VM rebuild is not required.
-	if !d.Recreate && opencodeConfigChanged {
+	if !d.Recreate && flags.OpenCodeConfig {
 		d.RestartDaemons = true
 		d.Changes = append(
 			d.Changes,

--- a/internal/sandbox/reprovision/plan_reconfig_test.go
+++ b/internal/sandbox/reprovision/plan_reconfig_test.go
@@ -103,7 +103,7 @@ func TestPlanReconfigDecidesRecreate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := PlanReconfig(tc.cfg, tc.imageRef, tc.opts, false, false, false, false, tc.homeVol).Recreate
+			got := PlanReconfig(tc.cfg, tc.imageRef, tc.opts, ChangeFlags{}, tc.homeVol).Recreate
 			if got != tc.want {
 				t.Errorf("PlanReconfig().Recreate = %v, want %v", got, tc.want)
 			}

--- a/internal/sandbox/reprovision/plan_test.go
+++ b/internal/sandbox/reprovision/plan_test.go
@@ -36,10 +36,7 @@ func TestPlanReconfigServeOnly(t *testing.T) {
 				cfg,
 				"img",
 				options.RunOptions{ServeOnly: tt.serveOnly},
-				false,
-				false,
-				false,
-				false,
+				ChangeFlags{},
 				"",
 			)
 			if plan.Recreate != tt.wantRecreate {
@@ -68,10 +65,7 @@ func TestPlanReconfigTriggersRecreateOnImageChange(t *testing.T) {
 		cfg,
 		"opencode-sandbox/runner-proj:oldhash",
 		options.RunOptions{},
-		false,
-		false,
-		false,
-		false,
+		ChangeFlags{},
 		"",
 	)
 	if planSame.Recreate {
@@ -82,10 +76,7 @@ func TestPlanReconfigTriggersRecreateOnImageChange(t *testing.T) {
 		cfg,
 		"opencode-sandbox/runner-proj:newhash",
 		options.RunOptions{},
-		false,
-		false,
-		false,
-		false,
+		ChangeFlags{},
 		"",
 	)
 	if !planNew.Recreate {
@@ -126,7 +117,7 @@ func TestDesiredPublishBindingsNilWhenNotServeOnly(t *testing.T) {
 func TestPlanReconfigNetworkChangeTriggersRecreate(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{}
 	opts := options.RunOptions{}
-	plan := PlanReconfig(cfg, "img", opts, false, false, true, false, "")
+	plan := PlanReconfig(cfg, "img", opts, ChangeFlags{Network: true}, "")
 	if !plan.Recreate {
 		t.Fatal("expected Recreate when network policy changes")
 	}
@@ -135,7 +126,7 @@ func TestPlanReconfigNetworkChangeTriggersRecreate(t *testing.T) {
 func TestPlanReconfigNetworkSameNoRecreate(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{}
 	opts := options.RunOptions{}
-	plan := PlanReconfig(cfg, "img", opts, false, false, false, false, "")
+	plan := PlanReconfig(cfg, "img", opts, ChangeFlags{}, "")
 	if plan.Recreate {
 		t.Fatal("expected no Recreate when network policy is unchanged")
 	}
@@ -148,7 +139,7 @@ func TestPlanReconfigHomeVolumeChangeTriggersRecreate(t *testing.T) {
 			VMHomeDir: {Named: "opencode-sandbox-home-proj-old"},
 		},
 	}
-	plan := PlanReconfig(cfg, "img", options.RunOptions{}, false, false, false, false,
+	plan := PlanReconfig(cfg, "img", options.RunOptions{}, ChangeFlags{},
 		"opencode-sandbox-home-proj-new")
 	if !plan.Recreate {
 		t.Fatal("expected Recreate when the desired home volume differs from the mounted one")
@@ -172,7 +163,7 @@ func TestPlanReconfigHomeVolumeSameNoRecreate(t *testing.T) {
 			VMHomeDir: {Named: "opencode-sandbox-home-proj-vol"},
 		},
 	}
-	plan := PlanReconfig(cfg, "img", options.RunOptions{}, false, false, false, false,
+	plan := PlanReconfig(cfg, "img", options.RunOptions{}, ChangeFlags{},
 		"opencode-sandbox-home-proj-vol")
 	if plan.Recreate {
 		t.Fatal("expected no Recreate when the mounted home volume matches the desired one")
@@ -180,9 +171,41 @@ func TestPlanReconfigHomeVolumeSameNoRecreate(t *testing.T) {
 }
 
 func TestPlanReconfigNilCfgHomeVolumeSafe(t *testing.T) {
-	plan := PlanReconfig(nil, "img", options.RunOptions{}, false, false, false, false,
+	plan := PlanReconfig(nil, "img", options.RunOptions{}, ChangeFlags{},
 		"opencode-sandbox-home-proj-vol")
 	if plan.Recreate {
 		t.Fatal("expected no Recreate for a nil config (fresh VM creation)")
+	}
+}
+
+func TestPlanReconfigMountsChangeTriggersRecreate(t *testing.T) {
+	cfg := &msbSdk.SandboxConfig{}
+	plan := PlanReconfig(cfg, "img", options.RunOptions{}, ChangeFlags{Mounts: true}, "")
+	if !plan.Recreate {
+		t.Fatal("expected Recreate when host bind mounts change")
+	}
+	found := false
+	for _, c := range plan.Changes {
+		if c.Label == changeLabelBindMounts {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q change label, got %+v", changeLabelBindMounts, plan.Changes)
+	}
+}
+
+// TestPlanReconfigMountsUnchangedNoRecreate guards the regression where the
+// plan was derived from cfg.Volumes, which the SDK never populates when
+// reading an existing VM back: every run would then rebuild the VM.
+func TestPlanReconfigMountsUnchangedNoRecreate(t *testing.T) {
+	cfg := &msbSdk.SandboxConfig{}
+	opts := options.RunOptions{Mounts: options.Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2"},
+	}}
+	plan := PlanReconfig(cfg, "img", opts, ChangeFlags{}, "")
+	if plan.Recreate {
+		t.Fatalf("expected no Recreate for unchanged mounts, got %+v", plan.Changes)
 	}
 }

--- a/internal/sandbox/reprovision/reconfig_test.go
+++ b/internal/sandbox/reprovision/reconfig_test.go
@@ -15,7 +15,7 @@ func TestPlanReconfigRecreateOnTmpMismatch(t *testing.T) {
 		Volumes: map[string]msbSdk.MountConfig{tmpMountPath: {SizeMiB: 2048}},
 	}
 	d := PlanReconfig(cfg, "img:tag", options.RunOptions{TmpSize: "4G"},
-		false, false, false, false, "")
+		ChangeFlags{}, "")
 	if !d.Recreate {
 		t.Error("expected recreate on /tmp size mismatch")
 	}
@@ -25,12 +25,12 @@ func TestPlanReconfigRecreateOnTmpMismatch(t *testing.T) {
 }
 
 func TestPlanReconfigRecreateOnImageMismatch(t *testing.T) {
-	d := PlanReconfig(nil, "new:tag", options.RunOptions{}, false, false, false, false, "")
+	d := PlanReconfig(nil, "new:tag", options.RunOptions{}, ChangeFlags{}, "")
 	if d.Recreate {
 		t.Error("image comparison requires cfg.Image; see resolver, planner.cpp nil-cfg safe")
 	}
 	cfg := &msbSdk.SandboxConfig{Image: "old:tag"}
-	d = PlanReconfig(cfg, "new:tag", options.RunOptions{}, false, false, false, false, "")
+	d = PlanReconfig(cfg, "new:tag", options.RunOptions{}, ChangeFlags{}, "")
 	if !d.Recreate {
 		t.Error("expected recreate on image mismatch")
 	}
@@ -38,7 +38,7 @@ func TestPlanReconfigRecreateOnImageMismatch(t *testing.T) {
 
 func TestPlanReconfigStagesClampedCpus(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{CPUs: 2, MaxCPUs: 8}
-	d := PlanReconfig(cfg, "img", options.RunOptions{CPUs: 16}, false, false, false, false, "")
+	d := PlanReconfig(cfg, "img", options.RunOptions{CPUs: 16}, ChangeFlags{}, "")
 	if d.Resources == nil || d.Resources.CPUs != 8 {
 		t.Fatalf("expected resources clamped CPUs=8, got %+v", d.Resources)
 	}
@@ -47,7 +47,7 @@ func TestPlanReconfigStagesClampedCpus(t *testing.T) {
 func TestPlanReconfigNoActionsWhenUnchanged(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{CPUs: 4, MemoryMiB: 4096}
 	d := PlanReconfig(cfg, "img", options.RunOptions{CPUs: 4, Memory: "4G"},
-		false, false, false, false, "")
+		ChangeFlags{}, "")
 	if d.Recreate || d.RestartDaemons || d.Resources != nil {
 		t.Errorf("expected no actions, got %+v", d)
 	}
@@ -95,7 +95,7 @@ func TestResolveReconfigPromptBKeepReturnsNoRestart(t *testing.T) {
 
 func TestPlanReconfigEnvChangeRebuildsVM(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{Image: "a", CPUs: 4, MemoryMiB: 4096}
-	d := PlanReconfig(cfg, "a", options.RunOptions{}, true, false, false, false, "") // envChanged=true
+	d := PlanReconfig(cfg, "a", options.RunOptions{}, ChangeFlags{Env: true}, "") // envChanged=true
 	if !d.Recreate {
 		t.Error("expected recreate on env change (env cannot be applied live)")
 	}
@@ -106,7 +106,13 @@ func TestPlanReconfigEnvChangeRebuildsVM(t *testing.T) {
 
 func TestPlanReconfigOpenCodeConfigChangeRestartsDaemon(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{Image: "a", CPUs: 4, MemoryMiB: 4096}
-	d := PlanReconfig(cfg, "a", options.RunOptions{}, false, false, false, true, "") // opencodeConfigChanged=true
+	d := PlanReconfig(
+		cfg,
+		"a",
+		options.RunOptions{},
+		ChangeFlags{OpenCodeConfig: true},
+		"",
+	) // opencodeConfigChanged=true
 	if !d.RestartDaemons {
 		t.Error("expected restartDaemons on opencode config change")
 	}
@@ -117,7 +123,7 @@ func TestPlanReconfigOpenCodeConfigChangeRestartsDaemon(t *testing.T) {
 
 func TestPlanReconfigSecretsChangeRebuildsVM(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{Image: "a", CPUs: 4, MemoryMiB: 4096}
-	d := PlanReconfig(cfg, "a", options.RunOptions{}, false, true, false, false, "") // secretsChanged=true
+	d := PlanReconfig(cfg, "a", options.RunOptions{}, ChangeFlags{Secrets: true}, "") // secretsChanged=true
 	if !d.Recreate {
 		t.Error("expected recreate on secrets change (secrets cannot be applied live)")
 	}
@@ -131,7 +137,7 @@ func TestPlanReconfigEnvWithRecreateNoRestartFlag(t *testing.T) {
 		tmpMountPath: {SizeMiB: 2048},
 	}}
 	// image mismatch triggers recreate, env change would add restartDaemons
-	d := PlanReconfig(cfg, "new:tag", options.RunOptions{TmpSize: "4G"}, true, false, false, false, "")
+	d := PlanReconfig(cfg, "new:tag", options.RunOptions{TmpSize: "4G"}, ChangeFlags{Env: true}, "")
 	if !d.Recreate {
 		t.Error("expected recreate on image mismatch")
 	}
@@ -142,7 +148,7 @@ func TestPlanReconfigEnvWithRecreateNoRestartFlag(t *testing.T) {
 
 func TestPlanReconfigMemoryClampToMax(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{Image: "a", MemoryMiB: 4096, MaxMemoryMiB: 8192}
-	d := PlanReconfig(cfg, "a", options.RunOptions{Memory: "16G"}, false, false, false, false, "")
+	d := PlanReconfig(cfg, "a", options.RunOptions{Memory: "16G"}, ChangeFlags{}, "")
 	if d.Resources == nil {
 		t.Fatal("expected resources set for memory change")
 	}

--- a/internal/sandbox/state/state.go
+++ b/internal/sandbox/state/state.go
@@ -40,6 +40,9 @@ type SecretState = FingerprintState
 // NetworkState tracks network-policy fingerprint data for a project.
 type NetworkState = FingerprintState
 
+// MountState tracks host bind-mount fingerprint data for a project.
+type MountState = FingerprintState
+
 // HomeState represents the per-project state file contents.
 type HomeState struct {
 	HomeVolume   string       `yaml:"home_volume"`
@@ -47,6 +50,7 @@ type HomeState struct {
 	EnvState     EnvState     `yaml:"env_state,omitempty"`
 	SecretState  SecretState  `yaml:"secret_state,omitempty"`
 	NetworkState NetworkState `yaml:"network_state,omitempty"`
+	MountState   MountState   `yaml:"mount_state,omitempty"`
 }
 
 // NewHomeState returns a HomeState with a zeroed EnvState/SecretState, ready

--- a/internal/sandbox/state/state_test.go
+++ b/internal/sandbox/state/state_test.go
@@ -215,3 +215,31 @@ func TestHomeState_ZeroEnvSecretOmitted(t *testing.T) {
 		t.Error("expected secret_state to be omitted from YAML when zero")
 	}
 }
+
+func TestWriteAndReadState_MountRoundTrip(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+	slug := "mountproj-abc123"
+
+	input := HomeState{
+		HomeVolume:  "opencode-sandbox-home-mountproj",
+		ImageDigest: "sha256:feedface",
+		MountState: MountState{
+			Hash:  "sha256:mounthash",
+			Names: []string{"/home/dev/.m2"},
+		},
+	}
+	if err := WriteState(slug, input); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+
+	result, err := ReadState(slug)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if result.MountState.Hash != input.MountState.Hash {
+		t.Errorf("MountState.Hash = %q, want %q", result.MountState.Hash, input.MountState.Hash)
+	}
+	if len(result.MountState.Names) != 1 || result.MountState.Names[0] != "/home/dev/.m2" {
+		t.Errorf("MountState.Names = %v, want [/home/dev/.m2]", result.MountState.Names)
+	}
+}

--- a/internal/sandbox/vm/coverage_extra_test.go
+++ b/internal/sandbox/vm/coverage_extra_test.go
@@ -98,7 +98,7 @@ func TestPersistConfigHashesCoversEnvSecretAndNetwork(t *testing.T) {
 	slug := "hashproj"
 	policy := network.Policy{Profile: network.ProfileNone}
 
-	persistConfigHashes(slug, policy, &ui)
+	persistConfigHashes(slug, policy, nil, &ui)
 
 	st, err := state.ReadState(slug)
 	if err != nil {
@@ -106,6 +106,9 @@ func TestPersistConfigHashesCoversEnvSecretAndNetwork(t *testing.T) {
 	}
 	if st.NetworkState.Hash == "" {
 		t.Error("expected network state hash to be persisted")
+	}
+	if st.MountState.Hash == "" {
+		t.Error("expected mount state hash to be persisted")
 	}
 }
 

--- a/internal/sandbox/vm/prepare_sandbox_test.go
+++ b/internal/sandbox/vm/prepare_sandbox_test.go
@@ -535,3 +535,93 @@ func TestPrepareSandboxWarnsWhenRecordingVersionFails(t *testing.T) {
 		t.Errorf("expected a version-recording warning, got %v", ui.WarnCalls)
 	}
 }
+
+// TestPrepareSandboxPersistsMountFingerprintOnVMCreation verifies that a
+// freshly created project VM records the configured bind mounts in the state
+// file. Without this fingerprint the next run would compare against an empty
+// state, report a mount change and recreate the VM on every startup.
+func TestPrepareSandboxPersistsMountFingerprintOnVMCreation(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+
+	sandboximage.WithMockOpenCodeVersionResolver(t, func(_ context.Context, req string) (string, error) {
+		return req, nil
+	})
+	origUpgradeInfo := openCodeUpgradeInfo
+	openCodeUpgradeInfo = func(_ context.Context) (string, error) { return "1.5.0", nil }
+	t.Cleanup(func() { openCodeUpgradeInfo = origUpgradeInfo })
+	if err := saveUpgradeState(upgradeState{CurrentVersion: "1.5.0"}); err != nil {
+		t.Fatalf("saveUpgradeState: %v", err)
+	}
+
+	docker.WithDockerMock(t, &docker.MockDockerClient{
+		ImageBuildFn: func(_ context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{Body: io.NopCloser(strings.NewReader(""))}, nil
+		},
+		ImageInspectFn: func(_ context.Context, _ string, _ ...client.ImageInspectOption) (client.ImageInspectResult, error) {
+			return client.ImageInspectResult{
+				InspectResponse: mobyimage.InspectResponse{
+					ID: "sha256:abc123",
+					Config: &dockerspec.DockerOCIImageConfig{
+						ImageConfig: ocispec.ImageConfig{
+							Labels: map[string]string{sandboximage.OpenCodeVersionLabel: "1.5.0"},
+						},
+					},
+				},
+			}, nil
+		},
+	})
+
+	slug := git.ProjectSlug()
+	vmFS := msb.NewTestFS(nil, nil)
+	createdSb := &msb.MockSandbox{Name_: projectVMName(slug), FSValue_: vmFS, ShellOut: map[string]msb.ShellResult{
+		dockerdBinaryCheckCmd: msb.NewTestResult(false, 1, "", "", nil),
+	}}
+	// No sandbox handle is registered, so GetSandbox reports "not found" and
+	// PrepareSandbox takes the create path (boot == vmBootCreated).
+	mock := &msb.MockMsbClient{
+		ImageGetFn:     func(_ context.Context, _ string) error { return nil },
+		CreatedSandbox: createdSb,
+		Volumes:        []msb.VolumeHandle{&msb.MockVolumeHandle{Name_: "home-vol"}},
+	}
+	msb.WithMsbMock(t, mock)
+
+	if err := state.WriteState(slug, state.HomeState{
+		HomeVolume:  "home-vol",
+		ImageDigest: "sha256:abc123",
+	}); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+
+	origDaemon := SetDaemonShellFunc(func(_ context.Context, _ msb.Sandbox, command string) (string, int, error) {
+		if command == "curl -sfm2 "+daemonHealthURL {
+			return `{"healthy":true,"version":"test"}`, 0, nil
+		}
+		return "", 0, nil
+	})
+	defer SetDaemonShellFunc(origDaemon)
+
+	mounts := options.Mounts{
+		"/home/dev/.m2": {Source: filepath.Join(t.TempDir(), "m2")},
+	}
+	ui := termio.NewTestMock(t)
+	sess, err := PrepareSandbox(context.Background(), options.RunOptions{Mounts: mounts}, &ui)
+	if err != nil {
+		t.Fatalf("PrepareSandbox: %v", err)
+	}
+	defer sess.Cleanup()
+
+	if len(mock.CreatedSandboxes) != 1 {
+		t.Fatalf("expected the project VM to be created, got %d creations", len(mock.CreatedSandboxes))
+	}
+
+	st, err := state.ReadState(slug)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if st.MountState.Hash != options.Fingerprint(mounts) {
+		t.Errorf("MountState.Hash = %q, want %q", st.MountState.Hash, options.Fingerprint(mounts))
+	}
+	if len(st.MountState.Names) != 1 || st.MountState.Names[0] != "/home/dev/.m2" {
+		t.Errorf("MountState.Names = %v, want [/home/dev/.m2]", st.MountState.Names)
+	}
+}

--- a/internal/sandbox/vm/reconfig.go
+++ b/internal/sandbox/vm/reconfig.go
@@ -168,15 +168,19 @@ func decideReconfig(
 	envHasChanged := reprovision.EnvChanged(hs.EnvState, desiredEnv)
 	secretsHasChanged := reprovision.SecretsChanged(hs.SecretState, desiredSecrets)
 	networkHasChanged := reprovision.NetworkChanged(hs.NetworkState, opts.Network)
+	mountsHaveChanged := reprovision.MountsChanged(hs.MountState, opts.Mounts)
 
 	plan := reprovision.PlanReconfig(
 		curCfg,
 		imageRef,
 		opts,
-		envHasChanged,
-		secretsHasChanged,
-		networkHasChanged,
-		opencfgChanged,
+		reprovision.ChangeFlags{
+			Env:            envHasChanged,
+			Secrets:        secretsHasChanged,
+			Network:        networkHasChanged,
+			Mounts:         mountsHaveChanged,
+			OpenCodeConfig: opencfgChanged,
+		},
 		homeVol,
 	)
 	otherClients := state.CountActiveClients(slug)

--- a/internal/sandbox/vm/run_envstate.go
+++ b/internal/sandbox/vm/run_envstate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/reprovision"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 )
@@ -33,5 +34,18 @@ func persistNetworkState(slug string, policy network.Policy) error {
 		}
 	}
 	st.NetworkState = reprovision.BuildNetworkState(policy)
+	return state.WriteState(slug, *st)
+}
+
+func persistMountState(slug string, mounts options.Mounts) error {
+	st, err := state.ReadState(slug)
+	if err != nil {
+		if errors.Is(err, state.ErrStateNotFound) {
+			st = new(state.HomeState)
+		} else {
+			return fmt.Errorf("read state for mount persistence: %w", err)
+		}
+	}
+	st.MountState = reprovision.BuildMountState(mounts)
 	return state.WriteState(slug, *st)
 }

--- a/internal/sandbox/vm/run_envstate_test.go
+++ b/internal/sandbox/vm/run_envstate_test.go
@@ -902,3 +902,50 @@ func errIsContains(err error, sub string) bool {
 func containsStr(s, sub string) bool {
 	return len(s) >= len(sub) && contains(s, sub)
 }
+
+// TestPersistMountState_NilStateOnNotFound tests persistMountState when no
+// state file exists yet, e.g. the very first run of a project.
+func TestPersistMountState_NilStateOnNotFound(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+
+	slug := "freshmountproject"
+	mounts := options.Mounts{
+		"/home/dev/.m2": {Source: "/host/.m2"},
+	}
+
+	if err := persistMountState(slug, mounts); err != nil {
+		t.Fatalf("persistMountState: %v", err)
+	}
+
+	got, err := state.ReadState(slug)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.HomeVolume != "" {
+		t.Error("expected empty HomeVolume for newly created state")
+	}
+	if got.MountState.Hash != options.Fingerprint(mounts) {
+		t.Errorf("MountState.Hash = %q, want %q", got.MountState.Hash, options.Fingerprint(mounts))
+	}
+}
+
+// TestPersistMountStateCorruptState covers the read-error branch, where the
+// state file exists but cannot be parsed.
+func TestPersistMountStateCorruptState(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+
+	slug := "corruptmountproject"
+	sdir := filepath.Join(configpaths.Get().UserStateDir(), slug)
+	if err := os.MkdirAll(sdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, sdir, "state.yaml", "{ corrupted: yaml: [")
+
+	err := persistMountState(slug, nil)
+	if err == nil {
+		t.Fatal("expected an error for a corrupt state file")
+	}
+	if !strings.Contains(err.Error(), "read state for mount persistence") {
+		t.Errorf("error = %v, want it to mention mount persistence", err)
+	}
+}

--- a/internal/sandbox/vm/run_orchestrate.go
+++ b/internal/sandbox/vm/run_orchestrate.go
@@ -131,7 +131,7 @@ func PrepareSandbox(
 		return nil, err
 	}
 	if boot == vmBootCreated {
-		persistConfigHashes(projectSlug, opts.Network, ui)
+		persistConfigHashes(projectSlug, opts.Network, opts.Mounts, ui)
 	}
 	name := projectVMName(projectSlug)
 
@@ -171,10 +171,15 @@ func resolveHomeVolume(
 	return vm.ResolveHomeVolume(ctx, client, projectSlug, info.Digest, info.Tag, dryRunVM, ui)
 }
 
-// persistConfigHashes records the desired env/secret/network fingerprints
-// when a project VM is freshly created (or recreated), so subsequent runs can
-// detect changes.
-func persistConfigHashes(projectSlug string, networkPolicy network.Policy, ui termio.UI) {
+// persistConfigHashes records the desired env/secret/network/mount
+// fingerprints when a project VM is freshly created (or recreated), so
+// subsequent runs can detect changes.
+func persistConfigHashes(
+	projectSlug string,
+	networkPolicy network.Policy,
+	mounts options.Mounts,
+	ui termio.UI,
+) {
 	desiredEnv := reprovision.MergeEnvMaps(
 		reprovision.BuildEnvMap(configpaths.Get().UserEnvFile()),
 		reprovision.BuildEnvMap(configpaths.Get().ProjectEnvFile()),
@@ -194,5 +199,8 @@ func persistConfigHashes(projectSlug string, networkPolicy network.Policy, ui te
 	}
 	if err := persistNetworkState(projectSlug, networkPolicy); err != nil {
 		ui.Warnf("persisting network fingerprint on VM creation: %v (continuing)", err)
+	}
+	if err := persistMountState(projectSlug, mounts); err != nil {
+		ui.Warnf("persisting mount fingerprint on VM creation: %v (continuing)", err)
 	}
 }

--- a/internal/sandbox/vm/setupsandbox_test.go
+++ b/internal/sandbox/vm/setupsandbox_test.go
@@ -20,7 +20,13 @@ import (
 )
 
 func TestBuildMountsIncludesTmpfsAtTmp(t *testing.T) {
-	mounts := buildMounts("test-home-vol", "/repo/path", options.DefaultTmpSizeMiB, options.DefaultWorkspaceQuotaMiB)
+	mounts := buildMounts(
+		"test-home-vol",
+		"/repo/path",
+		options.DefaultTmpSizeMiB,
+		options.DefaultWorkspaceQuotaMiB,
+		nil,
+	)
 
 	tmpMount, ok := mounts[tmpMountPath]
 	if !ok {
@@ -38,7 +44,7 @@ func TestBuildMountsIncludesTmpfsAtTmp(t *testing.T) {
 }
 
 func TestBuildMountsRespectsCustomTmpSize(t *testing.T) {
-	mounts := buildMounts("test-home-vol", "/repo/path", 4096, options.DefaultWorkspaceQuotaMiB)
+	mounts := buildMounts("test-home-vol", "/repo/path", 4096, options.DefaultWorkspaceQuotaMiB, nil)
 
 	tmpMount := mounts[tmpMountPath]
 	if tmpMount.SizeMiB != 4096 {
@@ -47,7 +53,7 @@ func TestBuildMountsRespectsCustomTmpSize(t *testing.T) {
 }
 
 func TestBuildMountsSetsWorkspaceQuota(t *testing.T) {
-	mounts := buildMounts("test-home-vol", "/repo/path", options.DefaultTmpSizeMiB, 32*1024)
+	mounts := buildMounts("test-home-vol", "/repo/path", options.DefaultTmpSizeMiB, 32*1024, nil)
 
 	wsMount, ok := mounts[defaultTargetDir]
 	if !ok {
@@ -62,7 +68,13 @@ func TestBuildMountsSetsWorkspaceQuota(t *testing.T) {
 }
 
 func TestBuildMountsWorkspaceQuotaDefault(t *testing.T) {
-	mounts := buildMounts("test-home-vol", "/repo/path", options.DefaultTmpSizeMiB, options.DefaultWorkspaceQuotaMiB)
+	mounts := buildMounts(
+		"test-home-vol",
+		"/repo/path",
+		options.DefaultTmpSizeMiB,
+		options.DefaultWorkspaceQuotaMiB,
+		nil,
+	)
 
 	wsMount, ok := mounts[defaultTargetDir]
 	if !ok {
@@ -70,6 +82,63 @@ func TestBuildMountsWorkspaceQuotaDefault(t *testing.T) {
 	}
 	if wsMount.QuotaMiB != options.DefaultWorkspaceQuotaMiB {
 		t.Errorf("expected /workspace default quota %d MiB, got %d", options.DefaultWorkspaceQuotaMiB, wsMount.QuotaMiB)
+	}
+}
+
+func TestBuildMountsIncludesConfiguredBindMount(t *testing.T) {
+	mounts := buildMounts(
+		"test-home-vol",
+		"/repo/path",
+		options.DefaultTmpSizeMiB,
+		options.DefaultWorkspaceQuotaMiB,
+		options.Mounts{
+			"/home/dev/.m2": {Source: "/host/home/.m2"},
+			"/home/dev/ref": {Source: "/host/ref", Readonly: true},
+		},
+	)
+
+	m2, ok := mounts["/home/dev/.m2"]
+	if !ok {
+		t.Fatalf("expected configured .m2 bind mount, got %v", mounts)
+	}
+	if m2.Kind() != msbSdk.MountKindBind {
+		t.Errorf("expected a bind mount, got kind %d", m2.Kind())
+	}
+	if m2.Bind != "/host/home/.m2" {
+		t.Errorf("bind source = %q, want /host/home/.m2", m2.Bind)
+	}
+	if m2.Readonly {
+		t.Error("expected .m2 to be writable")
+	}
+
+	ref, ok := mounts["/home/dev/ref"]
+	if !ok {
+		t.Fatal("expected configured readonly bind mount")
+	}
+	if !ref.Readonly {
+		t.Error("expected readonly to be propagated to the mount config")
+	}
+}
+
+// TestBuildMountsKeepsManagedMounts ensures configured mounts are additive and
+// never replace the managed home/workspace/tmp mounts.
+func TestBuildMountsKeepsManagedMounts(t *testing.T) {
+	mounts := buildMounts(
+		"test-home-vol",
+		"/repo/path",
+		options.DefaultTmpSizeMiB,
+		options.DefaultWorkspaceQuotaMiB,
+		options.Mounts{"/home/dev/.m2": {Source: "/host/.m2"}},
+	)
+
+	if home, ok := mounts[options.VMHomeDir]; !ok || home.Named != "test-home-vol" {
+		t.Errorf("managed home mount altered: %+v", mounts[options.VMHomeDir])
+	}
+	if ws, ok := mounts[defaultTargetDir]; !ok || ws.Bind != "/repo/path" {
+		t.Errorf("managed workspace mount altered: %+v", mounts[defaultTargetDir])
+	}
+	if tmp, ok := mounts[tmpMountPath]; !ok || tmp.Kind() != msbSdk.MountKindTmpfs {
+		t.Errorf("managed tmp mount altered: %+v", mounts[tmpMountPath])
 	}
 }
 

--- a/internal/sandbox/vm/small_error_test.go
+++ b/internal/sandbox/vm/small_error_test.go
@@ -74,12 +74,15 @@ func TestPersistConfigHashesWarnsOnError(t *testing.T) {
 	}
 	testutil.WriteFile(t, sdir, "state.yaml", "{ corrupted: yaml: [")
 
-	persistConfigHashes(slug, network.Policy{Profile: network.ProfileNone}, &ui)
+	persistConfigHashes(slug, network.Policy{Profile: network.ProfileNone}, nil, &ui)
 
 	if !contains(joinStrings(ui.WarnCalls), "persisting env/secret fingerprints") {
 		t.Errorf("expected a warning about persisting env/secret fingerprints, got %v", ui.WarnCalls)
 	}
 	if !contains(joinStrings(ui.WarnCalls), "persisting network fingerprint") {
 		t.Errorf("expected a warning about persisting the network fingerprint, got %v", ui.WarnCalls)
+	}
+	if !contains(joinStrings(ui.WarnCalls), "persisting mount fingerprint") {
+		t.Errorf("expected a warning about persisting the mount fingerprint, got %v", ui.WarnCalls)
 	}
 }

--- a/internal/sandbox/vm/vm_lifecycle.go
+++ b/internal/sandbox/vm/vm_lifecycle.go
@@ -296,6 +296,7 @@ func createProjectVM(
 		repoPath,
 		options.ResolveTmpSizeMiB(opts.TmpSize),
 		options.ResolveWorkspaceQuotaMiB(opts.WorkspaceQuota),
+		opts.Mounts,
 	)
 
 	spin := ui.Spinner("Starting project VM")
@@ -347,11 +348,15 @@ func createProjectVM(
 }
 
 // tmpMountPath is the mount point used for the sandbox tmpfs.
-const tmpMountPath = "/tmp"
+const tmpMountPath = options.TmpMountPath
 
-func buildMounts(homeVol, repoPath string, tmpSizeMiB uint32, workspaceQuotaMiB uint32) map[string]msbSdk.MountConfig {
-	return map[string]msbSdk.MountConfig{
-		"/home/dev": msbSdk.Mount.Named(homeVol, msbSdk.MountOptions{}),
+func buildMounts(
+	homeVol, repoPath string,
+	tmpSizeMiB, workspaceQuotaMiB uint32,
+	extra options.Mounts,
+) map[string]msbSdk.MountConfig {
+	mounts := map[string]msbSdk.MountConfig{
+		options.VMHomeDir: msbSdk.Mount.Named(homeVol, msbSdk.MountOptions{}),
 		defaultTargetDir: msbSdk.Mount.Bind(repoPath, msbSdk.MountOptions{
 			QuotaMiB: workspaceQuotaMiB,
 		}),
@@ -363,6 +368,10 @@ func buildMounts(homeVol, repoPath string, tmpSizeMiB uint32, workspaceQuotaMiB 
 			Nodev:    false,
 		}),
 	}
+	for target, mount := range extra {
+		mounts[target] = msbSdk.Mount.Bind(mount.Source, msbSdk.MountOptions{Readonly: mount.Readonly})
+	}
+	return mounts
 }
 
 // acquireProjectFlock takes an exclusive flock on the given path. It returns a

--- a/internal/sandbox/vm/worktree.go
+++ b/internal/sandbox/vm/worktree.go
@@ -13,7 +13,7 @@ import (
 	"github.com/inoio/opencode-sandbox/internal/termio"
 )
 
-const defaultTargetDir = "/workspace"
+const defaultTargetDir = options.WorkspaceMountPath
 
 type worktreeResponse struct {
 	Directory string `json:"directory"`

--- a/internal/sandbox/volume/operations.go
+++ b/internal/sandbox/volume/operations.go
@@ -222,15 +222,17 @@ func volumeOp(
 		return err
 	}
 
-	// Preserve the env/secret/network fingerprints from the previous state: a
-	// volume operation changes the home volume data, not the env/secrets/network
-	// baked into the VM, so discarding them would trigger a false VM rebuild on
-	// the next startup (see EnvChanged/SecretsChanged/NetworkChanged treating
-	// empty state as "changed").
+	// Preserve the env/secret/network/mount fingerprints from the previous
+	// state: a volume operation changes the home volume data, not the
+	// env/secrets/network/mounts baked into the VM, so discarding them would
+	// trigger a false VM rebuild on the next startup (see
+	// EnvChanged/SecretsChanged/NetworkChanged/MountsChanged treating empty
+	// state as "changed").
 	newState := state.NewHomeState(newVolumeName, currentDigest)
 	newState.EnvState = st.EnvState
 	newState.SecretState = st.SecretState
 	newState.NetworkState = st.NetworkState
+	newState.MountState = st.MountState
 	if err := state.WriteState(projectSlug, newState); err != nil {
 		ui.Warnf("failed to write state file: %v", err)
 	}

--- a/internal/viperconfig/viperconfig.go
+++ b/internal/viperconfig/viperconfig.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/yamlfmt"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -42,6 +43,7 @@ type Config struct {
 
 	// Network holds the egress policy. Only Profile is settable via env/flag.
 	Network network.Policy `mapstructure:"network"`
+	Mounts  options.Mounts `mapstructure:"-"`
 }
 
 // Resolver resolves launcher config with precedence flag > env > config > default.
@@ -102,6 +104,11 @@ func NewResolver(cmd *cobra.Command, slug string) (*Resolver, error) {
 	)); err != nil {
 		return nil, fmt.Errorf("decode launcher config: %w", err)
 	}
+	mounts, err := options.DecodeMounts(v.Get("mounts"))
+	if err != nil {
+		return nil, fmt.Errorf("decode launcher config: %w", err)
+	}
+	cfg.Mounts = mounts
 	return &Resolver{cfg: cfg}, nil
 }
 
@@ -405,4 +412,9 @@ func (r *Resolver) IdleTimeout() time.Duration     { return r.cfg.IdleTimeout() 
 // the policy is Empty.
 func (r *Resolver) Network() network.Policy {
 	return r.cfg.Network
+}
+
+// Mounts returns additional host bind mounts.
+func (r *Resolver) Mounts() options.Mounts {
+	return r.cfg.Mounts
 }

--- a/internal/viperconfig/viperconfig_test.go
+++ b/internal/viperconfig/viperconfig_test.go
@@ -49,6 +49,81 @@ func TestResolverIdleTimeoutDefault(t *testing.T) {
 	}
 }
 
+func TestResolverMounts(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+	cp := configpaths.Get()
+	testutil.WriteYAML(t, cp.UserConfigDir(), "config.yaml", map[string]any{
+		"mounts": map[string]any{
+			"/home/dev/.m2": "~/.m2",
+			"/home/dev/ref": map[string]any{"source": "/opt/company/reference", "readonly": true},
+		},
+	})
+
+	r, err := NewResolver(nil, "")
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	if len(r.Mounts()) != 2 {
+		t.Fatalf("Mounts = %+v", r.Mounts())
+	}
+	if got := r.Mounts()["/home/dev/.m2"]; got.Source != "~/.m2" || got.Readonly {
+		t.Errorf("Mounts = %+v", r.Mounts())
+	}
+	if got := r.Mounts()["/home/dev/ref"]; got.Source != "/opt/company/reference" || !got.Readonly {
+		t.Errorf("Mounts = %+v", r.Mounts())
+	}
+}
+
+func TestResolverMountsMergeByTarget(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+	cp := configpaths.Get()
+	testutil.WriteYAML(t, cp.UserConfigDir(), "config.yaml", map[string]any{
+		"mounts": map[string]any{
+			"/home/dev/.m2":    "~/.m2",
+			"/home/dev/shared": "/host/shared",
+		},
+	})
+	testutil.WriteYAML(t, cp.ProjectConfigDir(), "config.yaml", map[string]any{
+		"mounts": map[string]any{
+			"/home/dev/.m2": map[string]any{"source": "/project/.m2", "readonly": true},
+		},
+	})
+
+	r, err := NewResolver(nil, "")
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	if len(r.Mounts()) != 2 {
+		t.Fatalf("Mounts = %+v", r.Mounts())
+	}
+	if got := r.Mounts()["/home/dev/.m2"]; got.Source != "/project/.m2" || !got.Readonly {
+		t.Errorf("project override = %+v", got)
+	}
+	if got := r.Mounts()["/home/dev/shared"]; got.Source != "/host/shared" {
+		t.Errorf("user mount = %+v", got)
+	}
+}
+
+func TestResolverRejectsInvalidMountEntry(t *testing.T) {
+	configpaths.WithMockConfigPaths(t)
+	cp := configpaths.Get()
+	testutil.WriteYAML(t, cp.UserConfigDir(), "config.yaml", map[string]any{
+		"mounts": map[string]any{
+			"/home/dev/.m2": map[string]any{"readonly": "yes"},
+		},
+	})
+
+	_, err := NewResolver(nil, "")
+	if err == nil {
+		t.Fatal("expected invalid mount entry to fail")
+	}
+	for _, want := range []string{"decode launcher config", "/home/dev/.m2", "readonly must be a boolean"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
 func TestResolverEnvPrecedenceOverConfig(t *testing.T) {
 	configpaths.WithMockConfigPaths(t)
 	cp := configpaths.Get()


### PR DESCRIPTION
## Description

Adds a `mounts` list to the launcher config, exposing host directories inside the sandbox, e.g. to share the host Maven repository and settings:

```
mounts:
  - target: /home/dev/.m2
    source: ~/.m2
```

Sources may be absolute or start with `~/`. Mounts are writable unless `readonly: true` is set. `/home/dev`, `/workspace` and `/tmp` cannot be replaced; nesting inside `/workspace` or `/tmp` is rejected since it would hide managed content, while nesting inside the home volume is the common case.

Resolved mounts are handed to the microsandbox bind mount factory (`Mount.Bind` via `WithMounts`) at VM creation, see [msb bind mounts docs](https://docs.microsandbox.dev/sandboxes/volumes#bind-mounts).

Mounts are creation-only in microsandbox, so a change recreates the VM. Detection compares a fingerprint persisted in the project state file instead of the live VM config: the SDK does not populate SandboxConfig.Volumes when reading an existing VM back, so comparing against it would report a change on every run and rebuild the VM each time. This mirrors the existing network-policy handling, including carrying the fingerprint over on home-volume operations.

PlanReconfig would have grown to five positional bools, so they are now a named ChangeFlags struct.

## Checklist

- [ x] `make check` passes (fmt, lint, test)
- [ x] Tests added/updated
- [ x] `README.md` and `docs/` kept in sync with any behavior change