### PR TITLE
refactor(mounts): extract host bind-mount logic into sandbox/mounts package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,10 @@ persisting user state via a home directory volume.
 
 You are dogfooding the project, you are not on the host, but in an opencode-sandbox VM. Filesystem layout:
 
-- `/workspace` bind mount of the host CWD, mounted rw. When working there, there's potential for parallel edits by other
-  agents/humans.
-- `~/.local/share/opencode/worktree/` git worktrees of `/workspace`, created by opencode. If that's your CWD, when
-  finalizing the session, after merging/pushing, always delete the worktree.
+- `/workspace` bind mount of the host CWD, mounted rw. When working there, don't commit/revert/stash etc yourself: 
+  There's potential for parallel edits by other agents/humans. Always ask the user how to finalize the session.
+- `~/.local/share/opencode/worktree/` git worktrees of `/workspace`, created by opencode. If that's your CWD, finalize 
+  the session by pushing a PR to github and deleting the worktree.
 
 ## System tools
 

--- a/cmd/opencode-sandbox/cli_run_options_test.go
+++ b/cmd/opencode-sandbox/cli_run_options_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/termio"
@@ -382,7 +383,7 @@ func TestExtractRunOptionsNetworkInvalid(t *testing.T) {
 func TestExtractRunOptionsResolvesMounts(t *testing.T) {
 	ui := &termio.Mock{}
 	source := t.TempDir()
-	lc := launcherconfig.Config{Mounts: options.Mounts{
+	lc := launcherconfig.Config{Mounts: mounts.Mounts{
 		"/home/dev/.m2": {Source: source},
 	}}
 	cmd := buildCommandWithLauncherConfig(ui, lc)
@@ -405,11 +406,11 @@ func TestExtractRunOptionsResolvesMounts(t *testing.T) {
 func TestExtractRunOptionsRejectsInvalidMount(t *testing.T) {
 	cases := []struct {
 		name  string
-		mount options.Mounts
+		mount mounts.Mounts
 	}{
-		{"missing source", options.Mounts{"/home/dev/.m2": {Source: "/definitely/not/here"}}},
-		{"reserved target", options.Mounts{"/workspace": {Source: "/tmp"}}},
-		{"relative target", options.Mounts{"relative": {Source: "/tmp"}}},
+		{"missing source", mounts.Mounts{"/home/dev/.m2": {Source: "/definitely/not/here"}}},
+		{"reserved target", mounts.Mounts{"/workspace": {Source: "/tmp"}}},
+		{"relative target", mounts.Mounts{"relative": {Source: "/tmp"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/opencode-sandbox/commands.go
+++ b/cmd/opencode-sandbox/commands.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/inoio/opencode-sandbox/internal/git"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/naming"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
@@ -50,7 +51,7 @@ func extractRunOptions(cmd *cobra.Command, ui termio.UI) (options.RunOptions, er
 		opts.WorkspaceQuota = r.WorkspaceQuota()
 		opts.ReapPolicy = options.NewReapPolicy(r.AutoStopOnActiveSessions(), r.AutoStopMaxSessionRetries())
 		opts.IdleTimeout = r.IdleTimeout()
-		opts.Mounts, err = options.ResolveBindMounts(r.Mounts())
+		opts.Mounts, err = mounts.ResolveBindMounts(r.Mounts())
 		if err != nil {
 			return options.RunOptions{}, err
 		}

--- a/internal/sandbox/mounts/mounts.go
+++ b/internal/sandbox/mounts/mounts.go
@@ -1,4 +1,4 @@
-package options
+package mounts
 
 import (
 	"crypto/sha256"
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // Guest mount points that opencode-sandbox manages itself. They are fixed by
@@ -31,59 +34,42 @@ type BindMount struct {
 // Mounts maps absolute guest target paths to host bind-mount settings.
 type Mounts map[string]BindMount
 
-const (
-	mountFieldSource   = "source"
-	mountFieldReadonly = "readonly"
-)
+// stringToBindMountHook decodes the short mount form (`target: ~/.m2`) into a
+// writable BindMount. The long form (`target: {source, readonly}`) needs no
+// hook; mapstructure decodes it via the BindMount struct tags.
+func stringToBindMountHook() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String || t != reflect.TypeFor[BindMount]() {
+			return data, nil
+		}
+		source, ok := data.(string)
+		if !ok {
+			return nil, errors.New("bind mount source must be a string")
+		}
+		return BindMount{Source: source, Readonly: false}, nil
+	}
+}
 
-// DecodeMounts parses the launcher config's short and long mount forms.
+// DecodeMounts parses the launcher config's short and long mount forms,
+// delegating shape parsing to mapstructure. Unknown fields are ignored
+// (lenient); semantic validation is left to ResolveBindMounts.
 func DecodeMounts(raw any) (Mounts, error) {
 	if raw == nil {
 		return Mounts{}, nil
 	}
-	entries, ok := raw.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("mounts must be a mapping, got %T", raw)
+	var mounts Mounts
+	//nolint:exhaustruct // DecoderConfig has many optional fields we leave zeroed.
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: stringToBindMountHook(),
+		Result:     &mounts,
+	})
+	if err != nil {
+		return nil, err
 	}
-	mounts := make(Mounts, len(entries))
-	for target, rawEntry := range entries {
-		mount, err := decodeMount(rawEntry)
-		if err != nil {
-			return nil, fmt.Errorf("decode mount %q: %w", target, err)
-		}
-		mounts[target] = mount
+	if err := decoder.Decode(raw); err != nil {
+		return nil, err
 	}
 	return mounts, nil
-}
-
-func decodeMount(raw any) (BindMount, error) {
-	switch entry := raw.(type) {
-	case string:
-		return BindMount{Source: entry, Readonly: false}, nil
-	case map[string]any:
-		var mount BindMount
-		for key, value := range entry {
-			switch key {
-			case mountFieldSource:
-				source, ok := value.(string)
-				if !ok {
-					return BindMount{}, errors.New("source must be a string")
-				}
-				mount.Source = source
-			case mountFieldReadonly:
-				readonly, ok := value.(bool)
-				if !ok {
-					return BindMount{}, errors.New("readonly must be a boolean")
-				}
-				mount.Readonly = readonly
-			default:
-				return BindMount{}, fmt.Errorf("unknown field %q", key)
-			}
-		}
-		return mount, nil
-	default:
-		return BindMount{}, fmt.Errorf("value must be a source string or mapping, got %T", raw)
-	}
 }
 
 // managedMountTargets are the guest paths opencode-sandbox mounts itself. A

--- a/internal/sandbox/mounts/mounts_test.go
+++ b/internal/sandbox/mounts/mounts_test.go
@@ -1,10 +1,16 @@
-package options
+package mounts
 
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+// namedString is a defined string type: its reflection Kind is String, but it
+// is not assignable to a plain string. It drives the hook's assertion-failure
+// branch, which a plain string never reaches.
+type namedString string
 
 func TestDecodeMountsShortAndLongForms(t *testing.T) {
 	got, err := DecodeMounts(map[string]any{
@@ -25,6 +31,18 @@ func TestDecodeMountsShortAndLongForms(t *testing.T) {
 	}
 }
 
+func TestDecodeMountsIgnoresUnknownFields(t *testing.T) {
+	got, err := DecodeMounts(map[string]any{
+		"/home/dev/.m2": map[string]any{"source": "~/.m2", "read-only": true},
+	})
+	if err != nil {
+		t.Fatalf("DecodeMounts: %v", err)
+	}
+	if mount := got["/home/dev/.m2"]; mount.Source != "~/.m2" || mount.Readonly {
+		t.Errorf("unknown field must be ignored (lenient), got %+v", mount)
+	}
+}
+
 func TestDecodeMountsRejectsInvalid(t *testing.T) {
 	cases := []struct {
 		name string
@@ -34,7 +52,6 @@ func TestDecodeMountsRejectsInvalid(t *testing.T) {
 		{"invalid value", map[string]any{"/home/dev/.m2": true}},
 		{"source not string", map[string]any{"/home/dev/.m2": map[string]any{"source": true}}},
 		{"readonly not boolean", map[string]any{"/home/dev/.m2": map[string]any{"readonly": "yes"}}},
-		{"unknown field", map[string]any{"/home/dev/.m2": map[string]any{"read-only": true}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -52,6 +69,14 @@ func TestDecodeMountsNil(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("DecodeMounts(nil) = %+v, want empty", got)
+	}
+}
+
+func TestStringToBindMountHookRejectsNonStringSource(t *testing.T) {
+	hook := stringToBindMountHook()
+	_, err := hook(reflect.TypeFor[namedString](), reflect.TypeFor[BindMount](), namedString("~/.m2"))
+	if err == nil {
+		t.Fatal("expected the hook to reject a non-string source")
 	}
 }
 

--- a/internal/sandbox/options/options.go
+++ b/internal/sandbox/options/options.go
@@ -5,6 +5,7 @@ import (
 
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
 
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
 )
 
@@ -35,7 +36,7 @@ type RunOptions struct {
 	// (Empty) means no policy is set and the default public profile applies.
 	Network network.Policy
 	// Mounts are additional host directories bind-mounted at absolute guest paths.
-	Mounts Mounts
+	Mounts mounts.Mounts
 	// OpenCodeVersion pins the opencode version baked into the runner image on
 	// rebuild. Empty means resolve the latest at build time.
 	OpenCodeVersion string

--- a/internal/sandbox/reprovision/config_files.go
+++ b/internal/sandbox/reprovision/config_files.go
@@ -17,9 +17,9 @@ import (
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
 
 	config "github.com/inoio/opencode-sandbox/internal/opencodeconfig"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
-	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 	"github.com/inoio/opencode-sandbox/internal/termio"
 
@@ -54,7 +54,7 @@ func parseKeyValueLines(data string, onLine func(key, value string) error) error
 
 // VMHomeDir is the sandbox home mount point. It is fixed by the project VM
 // layout regardless of the configured runtime user.
-const VMHomeDir = options.VMHomeDir
+const VMHomeDir = mounts.VMHomeDir
 
 // OpenCodeConfigPath returns the VM path where the merged opencode config is
 // provisioned.
@@ -118,10 +118,10 @@ func LoadConfigFiles(userConfigDir string, ui termio.UI) (*ConfigFiles, error) {
 }
 
 // tmpMountPath is the mount point used for the sandbox tmpfs.
-const tmpMountPath = options.TmpMountPath
+const tmpMountPath = mounts.TmpMountPath
 
 // workspaceMountPath is the mount point used for the host bind mount.
-const workspaceMountPath = options.WorkspaceMountPath
+const workspaceMountPath = mounts.WorkspaceMountPath
 
 // ReadVMConfig reads the given absolute VM paths, returning a map of path to
 // content for files that exist.
@@ -330,17 +330,17 @@ func BuildNetworkState(desired network.Policy) state.NetworkState {
 // zero-value applied state indicates "no persisted state yet" (first run or a
 // VM created before mounts existed); it is only considered "changed" when
 // mounts are actually configured.
-func MountsChanged(applied state.MountState, desired options.Mounts) bool {
+func MountsChanged(applied state.MountState, desired mounts.Mounts) bool {
 	if applied.Hash == "" {
 		return len(desired) > 0
 	}
-	return applied.Hash != options.Fingerprint(desired)
+	return applied.Hash != mounts.Fingerprint(desired)
 }
 
 // BuildMountState computes the fingerprint for the desired host bind mounts.
-func BuildMountState(desired options.Mounts) state.MountState {
+func BuildMountState(desired mounts.Mounts) state.MountState {
 	return state.MountState{
-		Hash:  options.Fingerprint(desired),
-		Names: options.MountTargets(desired),
+		Hash:  mounts.Fingerprint(desired),
+		Names: mounts.MountTargets(desired),
 	}
 }

--- a/internal/sandbox/reprovision/config_hashes_test.go
+++ b/internal/sandbox/reprovision/config_hashes_test.go
@@ -5,8 +5,8 @@ import (
 
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
 
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
-	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 )
 
@@ -159,7 +159,7 @@ func TestBuildNetworkState(t *testing.T) {
 }
 
 func TestMountsChanged(t *testing.T) {
-	desired := options.Mounts{
+	desired := mounts.Mounts{
 		"/home/dev/.m2": {Source: "/host/.m2"},
 	}
 	applied := BuildMountState(desired)
@@ -170,7 +170,7 @@ func TestMountsChanged(t *testing.T) {
 	if !MountsChanged(applied, nil) {
 		t.Error("MountsChanged after removing all mounts should be true")
 	}
-	if !MountsChanged(applied, options.Mounts{
+	if !MountsChanged(applied, mounts.Mounts{
 		"/home/dev/.m2": {Source: "/host/.m2", Readonly: true},
 	}) {
 		t.Error("MountsChanged with a flipped readonly flag should be true")
@@ -183,7 +183,7 @@ func TestMountsChangedEmptyAppliedState(t *testing.T) {
 	if MountsChanged(state.MountState{}, nil) {
 		t.Error("MountsChanged with no persisted state and no mounts should be false")
 	}
-	if !MountsChanged(state.MountState{}, options.Mounts{
+	if !MountsChanged(state.MountState{}, mounts.Mounts{
 		"/home/dev/.m2": {Source: "/host/.m2"},
 	}) {
 		t.Error("MountsChanged with no persisted state and configured mounts should be true")
@@ -191,13 +191,13 @@ func TestMountsChangedEmptyAppliedState(t *testing.T) {
 }
 
 func TestBuildMountState(t *testing.T) {
-	desired := options.Mounts{
+	desired := mounts.Mounts{
 		"/home/dev/z": {Source: "/host/z"},
 		"/home/dev/a": {Source: "/host/a"},
 	}
 	st := BuildMountState(desired)
-	if st.Hash != options.Fingerprint(desired) {
-		t.Errorf("BuildMountState.Hash = %q, want %q", st.Hash, options.Fingerprint(desired))
+	if st.Hash != mounts.Fingerprint(desired) {
+		t.Errorf("BuildMountState.Hash = %q, want %q", st.Hash, mounts.Fingerprint(desired))
 	}
 	if len(st.Names) != 2 || st.Names[0] != "/home/dev/a" || st.Names[1] != "/home/dev/z" {
 		t.Errorf("BuildMountState.Names = %v, want sorted targets", st.Names)

--- a/internal/sandbox/reprovision/plan_test.go
+++ b/internal/sandbox/reprovision/plan_test.go
@@ -5,6 +5,7 @@ import (
 
 	msbSdk "github.com/superradcompany/microsandbox/sdk/go"
 
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 )
 
@@ -201,7 +202,7 @@ func TestPlanReconfigMountsChangeTriggersRecreate(t *testing.T) {
 // reading an existing VM back: every run would then rebuild the VM.
 func TestPlanReconfigMountsUnchangedNoRecreate(t *testing.T) {
 	cfg := &msbSdk.SandboxConfig{}
-	opts := options.RunOptions{Mounts: options.Mounts{
+	opts := options.RunOptions{Mounts: mounts.Mounts{
 		"/home/dev/.m2": {Source: "/host/.m2"},
 	}}
 	plan := PlanReconfig(cfg, "img", opts, ChangeFlags{}, "")

--- a/internal/sandbox/vm/prepare_sandbox_test.go
+++ b/internal/sandbox/vm/prepare_sandbox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/inoio/opencode-sandbox/internal/homeconfig"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/docker"
 	sandboximage "github.com/inoio/opencode-sandbox/internal/sandbox/image"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
@@ -600,11 +601,11 @@ func TestPrepareSandboxPersistsMountFingerprintOnVMCreation(t *testing.T) {
 	})
 	defer SetDaemonShellFunc(origDaemon)
 
-	mounts := options.Mounts{
+	mnts := mounts.Mounts{
 		"/home/dev/.m2": {Source: filepath.Join(t.TempDir(), "m2")},
 	}
 	ui := termio.NewTestMock(t)
-	sess, err := PrepareSandbox(context.Background(), options.RunOptions{Mounts: mounts}, &ui)
+	sess, err := PrepareSandbox(context.Background(), options.RunOptions{Mounts: mnts}, &ui)
 	if err != nil {
 		t.Fatalf("PrepareSandbox: %v", err)
 	}
@@ -618,8 +619,8 @@ func TestPrepareSandboxPersistsMountFingerprintOnVMCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadState: %v", err)
 	}
-	if st.MountState.Hash != options.Fingerprint(mounts) {
-		t.Errorf("MountState.Hash = %q, want %q", st.MountState.Hash, options.Fingerprint(mounts))
+	if st.MountState.Hash != mounts.Fingerprint(mnts) {
+		t.Errorf("MountState.Hash = %q, want %q", st.MountState.Hash, mounts.Fingerprint(mnts))
 	}
 	if len(st.MountState.Names) != 1 || st.MountState.Names[0] != "/home/dev/.m2" {
 		t.Errorf("MountState.Names = %v, want [/home/dev/.m2]", st.MountState.Names)

--- a/internal/sandbox/vm/run_envstate.go
+++ b/internal/sandbox/vm/run_envstate.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
-	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/reprovision"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/state"
 )
@@ -37,7 +37,7 @@ func persistNetworkState(slug string, policy network.Policy) error {
 	return state.WriteState(slug, *st)
 }
 
-func persistMountState(slug string, mounts options.Mounts) error {
+func persistMountState(slug string, mounts mounts.Mounts) error {
 	st, err := state.ReadState(slug)
 	if err != nil {
 		if errors.Is(err, state.ErrStateNotFound) {

--- a/internal/sandbox/vm/run_envstate_test.go
+++ b/internal/sandbox/vm/run_envstate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
 	"github.com/inoio/opencode-sandbox/internal/git"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
@@ -909,11 +910,11 @@ func TestPersistMountState_NilStateOnNotFound(t *testing.T) {
 	configpaths.WithMockConfigPaths(t)
 
 	slug := "freshmountproject"
-	mounts := options.Mounts{
+	mnts := mounts.Mounts{
 		"/home/dev/.m2": {Source: "/host/.m2"},
 	}
 
-	if err := persistMountState(slug, mounts); err != nil {
+	if err := persistMountState(slug, mnts); err != nil {
 		t.Fatalf("persistMountState: %v", err)
 	}
 
@@ -924,8 +925,8 @@ func TestPersistMountState_NilStateOnNotFound(t *testing.T) {
 	if got.HomeVolume != "" {
 		t.Error("expected empty HomeVolume for newly created state")
 	}
-	if got.MountState.Hash != options.Fingerprint(mounts) {
-		t.Errorf("MountState.Hash = %q, want %q", got.MountState.Hash, options.Fingerprint(mounts))
+	if got.MountState.Hash != mounts.Fingerprint(mnts) {
+		t.Errorf("MountState.Hash = %q, want %q", got.MountState.Hash, mounts.Fingerprint(mnts))
 	}
 }
 

--- a/internal/sandbox/vm/run_orchestrate.go
+++ b/internal/sandbox/vm/run_orchestrate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
 	"github.com/inoio/opencode-sandbox/internal/git"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/image"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
@@ -177,7 +178,7 @@ func resolveHomeVolume(
 func persistConfigHashes(
 	projectSlug string,
 	networkPolicy network.Policy,
-	mounts options.Mounts,
+	mounts mounts.Mounts,
 	ui termio.UI,
 ) {
 	desiredEnv := reprovision.MergeEnvMaps(

--- a/internal/sandbox/vm/setupsandbox_test.go
+++ b/internal/sandbox/vm/setupsandbox_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
 	"github.com/inoio/opencode-sandbox/internal/homeconfig"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/reprovision"
@@ -91,7 +92,7 @@ func TestBuildMountsIncludesConfiguredBindMount(t *testing.T) {
 		"/repo/path",
 		options.DefaultTmpSizeMiB,
 		options.DefaultWorkspaceQuotaMiB,
-		options.Mounts{
+		mounts.Mounts{
 			"/home/dev/.m2": {Source: "/host/home/.m2"},
 			"/home/dev/ref": {Source: "/host/ref", Readonly: true},
 		},
@@ -123,22 +124,22 @@ func TestBuildMountsIncludesConfiguredBindMount(t *testing.T) {
 // TestBuildMountsKeepsManagedMounts ensures configured mounts are additive and
 // never replace the managed home/workspace/tmp mounts.
 func TestBuildMountsKeepsManagedMounts(t *testing.T) {
-	mounts := buildMounts(
+	built := buildMounts(
 		"test-home-vol",
 		"/repo/path",
 		options.DefaultTmpSizeMiB,
 		options.DefaultWorkspaceQuotaMiB,
-		options.Mounts{"/home/dev/.m2": {Source: "/host/.m2"}},
+		mounts.Mounts{"/home/dev/.m2": {Source: "/host/.m2"}},
 	)
 
-	if home, ok := mounts[options.VMHomeDir]; !ok || home.Named != "test-home-vol" {
-		t.Errorf("managed home mount altered: %+v", mounts[options.VMHomeDir])
+	if home, ok := built[mounts.VMHomeDir]; !ok || home.Named != "test-home-vol" {
+		t.Errorf("managed home mount altered: %+v", built[mounts.VMHomeDir])
 	}
-	if ws, ok := mounts[defaultTargetDir]; !ok || ws.Bind != "/repo/path" {
-		t.Errorf("managed workspace mount altered: %+v", mounts[defaultTargetDir])
+	if ws, ok := built[defaultTargetDir]; !ok || ws.Bind != "/repo/path" {
+		t.Errorf("managed workspace mount altered: %+v", built[defaultTargetDir])
 	}
-	if tmp, ok := mounts[tmpMountPath]; !ok || tmp.Kind() != msbSdk.MountKindTmpfs {
-		t.Errorf("managed tmp mount altered: %+v", mounts[tmpMountPath])
+	if tmp, ok := built[tmpMountPath]; !ok || tmp.Kind() != msbSdk.MountKindTmpfs {
+		t.Errorf("managed tmp mount altered: %+v", built[tmpMountPath])
 	}
 }
 

--- a/internal/sandbox/vm/vm_lifecycle.go
+++ b/internal/sandbox/vm/vm_lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
 	"github.com/inoio/opencode-sandbox/internal/git"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/image"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/naming"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
@@ -348,15 +349,15 @@ func createProjectVM(
 }
 
 // tmpMountPath is the mount point used for the sandbox tmpfs.
-const tmpMountPath = options.TmpMountPath
+const tmpMountPath = mounts.TmpMountPath
 
 func buildMounts(
 	homeVol, repoPath string,
 	tmpSizeMiB, workspaceQuotaMiB uint32,
-	extra options.Mounts,
+	extra mounts.Mounts,
 ) map[string]msbSdk.MountConfig {
-	mounts := map[string]msbSdk.MountConfig{
-		options.VMHomeDir: msbSdk.Mount.Named(homeVol, msbSdk.MountOptions{}),
+	built := map[string]msbSdk.MountConfig{
+		mounts.VMHomeDir: msbSdk.Mount.Named(homeVol, msbSdk.MountOptions{}),
 		defaultTargetDir: msbSdk.Mount.Bind(repoPath, msbSdk.MountOptions{
 			QuotaMiB: workspaceQuotaMiB,
 		}),
@@ -369,9 +370,9 @@ func buildMounts(
 		}),
 	}
 	for target, mount := range extra {
-		mounts[target] = msbSdk.Mount.Bind(mount.Source, msbSdk.MountOptions{Readonly: mount.Readonly})
+		built[target] = msbSdk.Mount.Bind(mount.Source, msbSdk.MountOptions{Readonly: mount.Readonly})
 	}
-	return mounts
+	return built
 }
 
 // acquireProjectFlock takes an exclusive flock on the given path. It returns a

--- a/internal/sandbox/vm/worktree.go
+++ b/internal/sandbox/vm/worktree.go
@@ -8,12 +8,13 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/msb"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/termio"
 )
 
-const defaultTargetDir = options.WorkspaceMountPath
+const defaultTargetDir = mounts.WorkspaceMountPath
 
 type worktreeResponse struct {
 	Directory string `json:"directory"`

--- a/internal/viperconfig/viperconfig.go
+++ b/internal/viperconfig/viperconfig.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/inoio/opencode-sandbox/internal/configpaths"
+	"github.com/inoio/opencode-sandbox/internal/sandbox/mounts"
 	"github.com/inoio/opencode-sandbox/internal/sandbox/network"
-	"github.com/inoio/opencode-sandbox/internal/sandbox/options"
 	"github.com/inoio/opencode-sandbox/internal/yamlfmt"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -43,7 +43,10 @@ type Config struct {
 
 	// Network holds the egress policy. Only Profile is settable via env/flag.
 	Network network.Policy `mapstructure:"network"`
-	Mounts  options.Mounts `mapstructure:"-"`
+	// Mounts is excluded from viper.Unmarshal (mapstructure:"-") and decoded
+	// from v.Get("mounts") instead: viper flattens dotted guest paths such as
+	// /home/dev/.m2 into nested keys, which would corrupt the map keys.
+	Mounts mounts.Mounts `mapstructure:"-"`
 }
 
 // Resolver resolves launcher config with precedence flag > env > config > default.
@@ -104,7 +107,7 @@ func NewResolver(cmd *cobra.Command, slug string) (*Resolver, error) {
 	)); err != nil {
 		return nil, fmt.Errorf("decode launcher config: %w", err)
 	}
-	mounts, err := options.DecodeMounts(v.Get("mounts"))
+	mounts, err := mounts.DecodeMounts(v.Get("mounts"))
 	if err != nil {
 		return nil, fmt.Errorf("decode launcher config: %w", err)
 	}
@@ -415,6 +418,6 @@ func (r *Resolver) Network() network.Policy {
 }
 
 // Mounts returns additional host bind mounts.
-func (r *Resolver) Mounts() options.Mounts {
+func (r *Resolver) Mounts() mounts.Mounts {
 	return r.cfg.Mounts
 }

--- a/internal/viperconfig/viperconfig_test.go
+++ b/internal/viperconfig/viperconfig_test.go
@@ -117,7 +117,7 @@ func TestResolverRejectsInvalidMountEntry(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid mount entry to fail")
 	}
-	for _, want := range []string{"decode launcher config", "/home/dev/.m2", "readonly must be a boolean"} {
+	for _, want := range []string{"decode launcher config", "/home/dev/.m2", "expected type 'bool'"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not mention %q", err, want)
 		}


### PR DESCRIPTION
## Description

Refactors the mount subsystem introduced in #42 out of `internal/sandbox/options` into its own `internal/sandbox/mounts` package, mirroring the existing `internal/sandbox/network` precedent for self-contained, domain-specific config types.

Triggered by discussion on #42, the hand-rolled mount shape parser (`decodeMount` switch) is replaced with mapstructure decoding: a `string -> BindMount` decode hook handles the short form (`target: ~/.m2`), and `ResolveBindMounts` remains the validation layer (path existence, `~` expansion, target conflicts, duplicates). Decoding is fully lenient — unknown fields are ignored.

The managed mount-point constants (`VMHomeDir`, `WorkspaceMountPath`, `TmpMountPath`) move with the subsystem so the dependency direction stays `options -> mounts`, and `options` no longer imports `mapstructure`.

## Why not decode via viper's `Unmarshal`

A note for reviewers: the `mounts` map is decoded from `v.Get("mounts")` rather than through `viper.Unmarshal` because viper flattens dotted guest paths (e.g. `/home/dev/.m2` into nested keys), which would corrupt the map keys. This is documented on the `Config.Mounts` field.

## Checklist

- [x] `make check` passes (fmt, lint, test)
- [x] Tests added/updated
- [x] Internal refactor only — no behavior change, so no README/docs/CHANGELOG update warranted